### PR TITLE
Python 2.6 Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
  - pip install -r requirements-test.txt
  - pip install .
  - pip install coveralls
- - [ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && pip install importlib || true
+ - '[ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && pip install importlib || true'
 
 # scons is Python2 only!
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
  - pip install -r requirements-test.txt
  - pip install .
  - pip install coveralls
+ - [ "${TRAVIS_PYTHON_VERSION}" = "2.6" ] && pip install importlib || true
 
 # scons is Python2 only!
 


### PR DESCRIPTION
Recent builds for Python 2.6 on Travis were failing with giving a missing import error. This one should fix it.