### PR TITLE
Set child thread to daemon to avoid python hang.

### DIFF
--- a/pysimavr/logger.py
+++ b/pysimavr/logger.py
@@ -23,7 +23,10 @@ class SimavrLogger(object):
         '''
         '''
         use_mem_logger()
-        Thread(target=self._log_reader).start()
+        t = Thread(target=self._log_reader)
+        t.name = "Logger"
+        t.daemon = True
+        t.start()
 
     def __del__(self):
         self.terminate()

--- a/pysimavr/uart.py
+++ b/pysimavr/uart.py
@@ -19,7 +19,10 @@ class Uart():
         self._line_buffer = ''
         self.backend = uart_buff_t()
         uart_buff_init(avr.backend, self.backend)
-        Thread(target=self._uart_reader).start()
+        t = Thread(target=self._uart_reader)        
+        t.name = "Uart"
+        t.daemon = True
+        t.start()
 
     def connect(self):
         uart_buff_connect(self.backend, '0')


### PR DESCRIPTION
Python process just hangs when there is any exception in the avr.py \_init\_ after the logger or uar threads were already created. And there is no way to call the _terminate_ method from the client code since object has not been created. The main even loop is no longer running so the process doesn't even response to sigterm ... 

This way the child threads at least get killed automatically in such a case.