### PR TITLE
Timer Callback KeepAlive + cleanup - 2nd

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,6 +72,10 @@ high level interface
     :members:
     :undoc-members:
 
+.. automodule:: pysimavr.timer
+    :members:
+    :undoc-members:  
+
 .. automodule:: pysimavr.vcdfile
     :members:
     :undoc-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,10 @@ high level interface
     :members:
     :undoc-members:
 
+.. automodule:: pysimavr.logger
+    :members:
+    :undoc-members:
+
 .. automodule:: pysimavr.sgm7
     :members:
     :undoc-members:

--- a/pysimavr/logger.py
+++ b/pysimavr/logger.py
@@ -7,66 +7,69 @@ log = logging.getLogger(__name__)
 
 simavr_to_py_log_level = {
         LOG_OUTPUT:logging.FATAL,
-        LOG_ERROR:logging.ERROR, 
+        LOG_ERROR:logging.ERROR,
         LOG_WARNING:logging.WARNING,
-        LOG_TRACE:logging.DEBUG        
+        LOG_TRACE:logging.DEBUG
 }
 
 
 def pylogging_log(line, avr_log_level):
     """The default logging function utilising the python logging framework."""
-    py_log_level = simavr_to_py_log_level.get(avr_log_level, logging.DEBUG )
-    if not log.isEnabledFor(py_log_level): return;        
+    py_log_level = simavr_to_py_log_level.get(avr_log_level, logging.DEBUG)
+    if not log.isEnabledFor(py_log_level): return;
     log.log(py_log_level, line.strip());
 
 
 class SimavrLogger(LoggerCallback):
     """Consumes log statements from the core simavr logger and propagates
     them to the configured callback function. The default callback function is using 
-    the `pylogging_log` which uses python logging.
-    
-    Do not create instance of this class directly but use the provided `init_simavr_logger` module function instead. 
+    the :func:`pylogging_log` which uses python logging.
+
+    Do not create instance of this class directly but use the provided :func:`init_simavr_logger` module function instead. 
     """  
 
-       
     def __init__(self, callback=None):
         LoggerCallback.__init__(self)
-        #super(TimerCallback, self).__init__()
+        # super(TimerCallback, self).__init__()
         self._callback = callback
-        
+
     def on_log(self, line, avr_log_level):
+        """ Called by simavr to log a message.
+
+            :param line: The log message.
+            :param avr_log_level: Log message severity. One of the `pysimavr.swig.simavr.LOG_*` constants.
+        """
         if self._callback:
             try: self._callback(line, avr_log_level)
             except:
-                #Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
+                # Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
                 traceback.print_exc()
                 raise
-                
-            
+
     @property
     def callback(self):
         return self._callback;
-    
+
     @callback.setter
     def callback(self, callback):
         self._callback = callback
-        
+
 def get_simavr_logger():
+    """ :return: The global :class:`SimavrLogger` instance or `None` when not initialized yet. """
     if  '_simavr_logger' in globals():
         return globals()['_simavr_logger']
     return None 
 
-
 def init_simavr_logger(logger=pylogging_log):
     """Sets the logger callback. Use to redirect logs to a custom handler.
-    
+
     When using a custom logging function it is necessary to set the custom logger
-    before the `pysimavr.avr.Avr` is created. Otherwise some of the early simavr simavr log 
-    messages might get missed.
-    
-    Note the `avr_log_level` withe zero value (`pysimavr.swig.simavr.LOG_OUTPUT`) indicates the message is
-    an output for the simulated firmware. 
-    """  
+    before the :class:`~pysimavr.avr.Avr` is created. Otherwise some of the early simavr log 
+    messages might get lost.
+
+    Note the `avr_log_level` with zero value (`pysimavr.swig.simavr.LOG_OUTPUT`) indicates the message is
+    an output from the simulated firmware. 
+    """
     global _simavr_logger
     _simavr_logger = get_simavr_logger()
     if logger is None:

--- a/pysimavr/timer.py
+++ b/pysimavr/timer.py
@@ -2,22 +2,25 @@ from pysimavr.swig.utils import TimerCallback
 import traceback
 
 class Timer(TimerCallback):
-    """Wraps the simavr cycle_timer functionality. Enables to hook a python method
+    """ Wraps the simavr cycle_timer functionality. Enables to hook a python method
     to be called every x simavr cycles. 
-    """        
-    
+
+    Note there is usually no need to create instance of this class directly as there is a 
+    helper :func:`avr.timer <pysimavr.avr.Avr.timer>` method available.
+    """
+
     def __init__(self, avr, callback=None):
         TimerCallback.__init__(self, avr)
         #super(TimerCallback, self).__init__()
         self._callback = callback
-        
-    
+
+
     def on_timer(self, when):
         """ The callback called from simavr.
-        :Parameters:
-            `when` : The exact simavr cycle number. Note actual cycle number could be
+
+        :param when: The exact simavr cycle number. Note actual cycle number could be
                 slightly off the requested one.
-        :Returns: The new cycle number the next callback should be invoked. 
+        :return: The new cycle number the next callback should be invoked. 
                 Or zero to cancel the callback.           
         """
         if self._callback:
@@ -26,14 +29,11 @@ class Timer(TimerCallback):
                 #Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
                 traceback.print_exc()
                 raise
-            
-            
-            
+
     @property
     def callback(self):
         return self._callback;
-    
+
     @callback.setter
     def callback(self, callback):
         self._callback = callback
-    

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -4,25 +4,25 @@ from mock import Mock
 from nose.tools import eq_
 from pysimavr.avr import Avr
 from pysimavr.swig.simavr import cpu_Running 
-from hamcrest import assert_that, close_to, greater_than, equal_to, none, is_
+from hamcrest import assert_that, close_to, greater_than, equal_to, none, is_, not_none
 import weakref
 import gc
 
 def test_timer_simple():
-    avr = Avr(mcu='atmega88', f_cpu=8000000)    
+    avr = Avr(mcu='atmega88', f_cpu=8000000)
     # Callback method mocked out. 
     callbackMock = Mock(return_value=0)
-    
+
     #Schedule callback at 20uSec.  
     # cycles = avr->frequency * (avr_cycle_count_t)usec / 1000000;
     timer = avr.timer(callbackMock, uSec=20)
-         
+
     assert_that(timer.status(), close_to(8000000*20/1000000, 10), 
                 "uSec to cycles convertion")    
-    
+
     avr.step(1000)
     eq_(avr.state, cpu_Running, "mcu is not running")
-            
+
     eq_(callbackMock.call_count, 1, "number of calback invocations")
     avr.terminate()
 
@@ -31,44 +31,54 @@ def test_timer_reoccuring():
     # Callback method mocked out. It will register another callback 
     # at 200 cycles and then cancel by returning 0.
     callbackMock = Mock(side_effect = [200, 0])
-    
+
     timer = avr.timer(callbackMock)
     avr.step(10)
     eq_(avr.state, cpu_Running, "mcu is not running")
     callbackMock.assert_not_called()
-    
+
     # Request first timer callback at 100 cycles
     timer.set_timer_cycles(100)    
-    
+
     # Run long enought to ensure callback is canceled by returning 0 on the second invocation.
     avr.step(1000)
     eq_(avr.state, cpu_Running, "mcu is not running")
     eq_(callbackMock.call_count, 2, "number of calback invocations")
-        
+
     lastCallFirstArg = callbackMock.call_args[0][0]    
     assert_that(lastCallFirstArg, close_to(200, 10), 
                 "The last cycle number received in the callback doesn't match the requested one") 
     avr.terminate()
-    
+
 def test_timer_cancel():
     avr = Avr(mcu='atmega88', f_cpu=1000000)
     callbackMock = Mock(return_value=200)
     timer = avr.timer(callbackMock, cycle=50)    
     avr.step(10)
     callbackMock.assert_not_called()
-    
+
     timer.cancel()
     avr.step(1000)
     callbackMock.assert_not_called()    
-         
+
     avr.terminate()
-    
+
 def test_timer_GC():
     avr = Avr(mcu='atmega88', f_cpu=1000000)
     callbackMock = Mock(return_value=0)
-    t = weakref.ref(avr.timer(callbackMock, cycle=10))
+    #Don't let avr object to keep the callback referenced.
+    t = weakref.ref(avr.timer(callbackMock, cycle=10, keepalive=False))
     gc.collect()
     assert_that(t(), is_(none()), "Orphan Timer didn't get garbage collected.")
     avr.step(100)
-    assert_that(callbackMock.call_count, equal_to(0), "Number of IRQ callback invocations.")        
+    assert_that(callbackMock.call_count, equal_to(0), "Number of IRQ callback invocations.")
+
+    #Now let avr object keep the callback alive.
+    t = weakref.ref(avr.timer(callbackMock, cycle=110, keepalive=True))
+    gc.collect()
+    assert_that(t(), is_ (not_none()), "Avr object didn't kept Timer callback alive.")
+    avr.step(1000)
+    assert_that(callbackMock.call_count, equal_to(1), "Number of IRQ callback invocations.")                   
     avr.terminate()
+    gc.collect()
+    assert_that(t(), is_(none()), "Orphan Timer didn't get garbage collected even after Avr is terminated.")


### PR DESCRIPTION
- Added *keepAlive* flag so the registered callback function won't get unregistered once the result got out of scope. This would be more expected behaviour.
- Formating and Doc cleanup.