### PR TITLE
IRQ callback

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -72,6 +72,10 @@ high level interface
     :members:
     :undoc-members:
 
+.. automodule:: pysimavr.timer
+    :members:
+    :undoc-members:  
+
 .. automodule:: pysimavr.vcdfile
     :members:
     :undoc-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,10 @@ high level interface
     :members:
     :undoc-members:
 
+.. automodule:: pysimavr.logger
+    :members:
+    :undoc-members:
+
 .. automodule:: pysimavr.sgm7
     :members:
     :undoc-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,6 +60,10 @@ high level interface
     :members:
     :undoc-members:
 
+.. automodule:: pysimavr.irq
+    :members:
+    :undoc-members:
+
 .. automodule:: pysimavr.lcd
     :members:
     :undoc-members:

--- a/pysimavr/irq.py
+++ b/pysimavr/irq.py
@@ -1,0 +1,119 @@
+from pysimavr.swig.utils import IRQCallback as _IRQCallback
+from pysimavr.swig.simavr import avr_io_getirq
+import pysimavr.swig.utils as utils
+import traceback
+import weakref
+
+class IRQHelper(object):
+    """ Helper methods related to simavr IRQ functionality. Closely coupled with the
+    main :class:`~pysimavr.avr.Avr` instance. There is no need to create instance of this class directly since there is 
+    a pre-created one available already. Use the :attr:`avr.irq <pysimavr.avr.Avr.irq>` to access it.
+
+    All the **get...** methods return the :class:`~pysimavr.swig.simavr.avr_irq_t` instance and wrap various 
+    simavr `AVR_IOCTL_IOPORT_...` macros in convenient way.
+
+    All the **...register_notify** methods registers the provided callback function via the :class:`IRQCallback`. See 
+    the :func:`IRQCallback.on_notify` method for the callback function signature and more details.
+
+    The optional **keepAlive** parameter indicates the ownership of the returned  :class:`IRQCallback` object.
+    By default it is **True** which means there is an additional reference being held internally. That way the callback object
+    is not destroyed sooner than the main :class:`~pysimavr.avr.Avr` instance. 
+    When the `keepAlive` is set to `False` it is the callers responsibility to keep the returned object referenced for the desired lifetime
+    of the notifications.
+    """
+
+    def __init__(self, avr):
+        self._avr_ref = weakref.ref(avr)
+
+    def _keepAlive(self, irqcb):
+        self._avr_ref().callbacks_keepalive.append(irqcb)
+
+    @property
+    def _avrbackend(self):
+        return self._avr_ref().backend
+
+    def getioport(self, portPin):
+        """ Digital IO IRQ.
+
+        :param portPin: `(port, pin)` tuple.
+            The port is a single uppercase character like `"A"`.
+            The pin is one of the `pysimavr.swig.utils.IOPORT_IRQ_*` constants. For example `("A", IOPORT_IRQ_PIN_ALL)` tuple represents
+            all the 8 bits of the port. Note the `IOPORT_IRQ_PINx' constants are intentionally declared with values `0..7` in simavr.
+            So it is possible to use plain integers to address a specific pin of a port too. For example `("A", 6)` indicates *A6* port.
+        :return: An :class:`~pysimavr.swig.simavr.avr_irq_t` instance.
+        """
+        return avr_io_getirq(self._avrbackend, utils.AVR_IOCTL_IOPORT_GETIRQ(portPin[0]), int(portPin[1]))
+
+    def ioport_register_notify(self, callback, portPin, keepalive=True):
+        """ Register Digital IO port notification callback. 
+        Triggered each time the digital output port changes its state. Like value, direction or similar.
+
+        :param callback: A `callable(irq, newVal)`. See :func:`IRQCallback.on_notify`.
+        :param portPin: See the :func:`IRQHelper.getioport`.
+        :param keepalive: See the :class:`IRQHelper`.
+        :return: A :class:`~pysimavr.irq.IRQCallback` instance.
+        """
+        irq_t = self.getioport(portPin)
+        irqcb = IRQCallback(irq_t, callback)
+        if keepalive:
+            self._keepAlive(irqcb)
+        return irqcb;
+
+    def getadc(self, irqIndex):
+        """ Analog to Digital Converter IRQ.
+
+        :param irqIndex: The ADC IRQ type. One of the `pysimavr.swig.utils.AVR_IOCTL_ADC_*` constants.
+        :return: An :class:`~pysimavr.swig.simavr.avr_irq_t` instance.
+        """
+        return avr_io_getirq(self._avrbackend, utils.AVR_IOCTL_ADC_GETIRQ, irqIndex)
+
+    def adc_register_notify(self, callback, irqIndex=utils.ADC_IRQ_OUT_TRIGGER, keepalive=True):
+        """ Register ADC notification callback. 
+        Triggered when the ADC is started in code. To feed the ADC with a value another ADC IRQ
+        must be triggered using the :func:`~pysimavr.swig.simavr.avr_raise_irq` function.
+
+        :param callback: A `callable(irq, newVal)`. See :func:`IRQCallback.on_notify`.
+        :param portPin: See the :func:`IRQHelper.getioport`.
+        :param keepalive: See the :class:`IRQHelper`.
+        :return: A :class:`~pysimavr.irq.IRQCallback` instance.
+        """
+        irq_t = self.getadc(irqIndex)
+        irqcb = IRQCallback(irq_t, callback)
+        if keepalive:
+            self._keepAlive(irqcb)
+        return irqcb;
+
+class IRQCallback(_IRQCallback):
+    """ Wraps the simavr IRQ notifications which can be used to
+    receive events from the simulated avr and other attached parts.
+
+    Note when this object is destroyed the notification is unregistered automatically.
+    """
+
+    def __init__(self, irq,  callback=None):
+        _IRQCallback.__init__(self, irq)
+        self._callback = callback
+        #super(TimerCallback, self).__init__()
+
+    def on_notify(self, irq, newVal):
+        """ The callback method called from simavr.
+
+        :param irq: The original :class:`~pysimavr.swig.simavr.avr_irq_t` object this listener was registered with. Note
+            the `irq.value` contains the previous value.
+        :param newVal: An arbitrary integer parameter provided as part of the event. The real meaning is IRQ specific. For example it
+            could be `1, 0` for digital pins or an analog value (in milivolts) for ADC.
+        """
+        if self._callback:
+            try: return self._callback(irq, newVal)
+            except:
+                #Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost.
+                traceback.print_exc()
+                raise
+
+    @property
+    def callback(self):
+        return self._callback;
+
+    @callback.setter
+    def callback(self, callback):
+        self._callback = callback

--- a/pysimavr/logger.py
+++ b/pysimavr/logger.py
@@ -7,66 +7,69 @@ log = logging.getLogger(__name__)
 
 simavr_to_py_log_level = {
         LOG_OUTPUT:logging.FATAL,
-        LOG_ERROR:logging.ERROR, 
+        LOG_ERROR:logging.ERROR,
         LOG_WARNING:logging.WARNING,
-        LOG_TRACE:logging.DEBUG        
+        LOG_TRACE:logging.DEBUG
 }
 
 
 def pylogging_log(line, avr_log_level):
     """The default logging function utilising the python logging framework."""
-    py_log_level = simavr_to_py_log_level.get(avr_log_level, logging.DEBUG )
-    if not log.isEnabledFor(py_log_level): return;        
+    py_log_level = simavr_to_py_log_level.get(avr_log_level, logging.DEBUG)
+    if not log.isEnabledFor(py_log_level): return;
     log.log(py_log_level, line.strip());
 
 
 class SimavrLogger(LoggerCallback):
     """Consumes log statements from the core simavr logger and propagates
     them to the configured callback function. The default callback function is using 
-    the `pylogging_log` which uses python logging.
-    
-    Do not create instance of this class directly but use the provided `init_simavr_logger` module function instead. 
+    the :func:`pylogging_log` which uses python logging.
+
+    Do not create instance of this class directly but use the provided :func:`init_simavr_logger` module function instead. 
     """  
 
-       
     def __init__(self, callback=None):
         LoggerCallback.__init__(self)
-        #super(TimerCallback, self).__init__()
+        # super(TimerCallback, self).__init__()
         self._callback = callback
-        
+
     def on_log(self, line, avr_log_level):
+        """ Called by simavr to log a message.
+
+            :param line: The log message.
+            :param avr_log_level: Log message severity. One of the `pysimavr.swig.simavr.LOG_*` constants.
+        """
         if self._callback:
             try: self._callback(line, avr_log_level)
             except:
-                #Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
+                # Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
                 traceback.print_exc()
                 raise
-                
-            
+
     @property
     def callback(self):
         return self._callback;
-    
+
     @callback.setter
     def callback(self, callback):
         self._callback = callback
-        
+
 def get_simavr_logger():
+    """ :return: The global :class:`SimavrLogger` instance or `None` when not initialized yet. """
     if  '_simavr_logger' in globals():
         return globals()['_simavr_logger']
     return None 
 
-
 def init_simavr_logger(logger=pylogging_log):
     """Sets the logger callback. Use to redirect logs to a custom handler.
-    
+
     When using a custom logging function it is necessary to set the custom logger
-    before the `pysimavr.avr.Avr` is created. Otherwise some of the early simavr simavr log 
-    messages might get missed.
-    
-    Note the `avr_log_level` withe zero value (`pysimavr.swig.simavr.LOG_OUTPUT`) indicates the message is
-    an output for the simulated firmware. 
-    """  
+    before the :class:`~pysimavr.avr.Avr` is created. Otherwise some of the early simavr log 
+    messages might get lost.
+
+    Note the `avr_log_level` with zero value (`pysimavr.swig.simavr.LOG_OUTPUT`) indicates the message is
+    an output from the simulated firmware. 
+    """
     global _simavr_logger
     _simavr_logger = get_simavr_logger()
     if logger is None:

--- a/pysimavr/swig/utils.i
+++ b/pysimavr/swig/utils.i
@@ -1,24 +1,86 @@
 %module(directors="1") utils
 %include "constraints.i"
 
-
+// *********************************
+// * Callbacks                     *
+// *********************************
 %{
 #include "TimerCallback.h"
 #include "LoggerCallback.h"
-
+#include "IRQCallback.h"
 %}
 
 
 // Enable cross-language polymorphism in the SWIG wrapper. 
 %feature("director") TimerCallback;
 %feature("director") LoggerCallback;
+%feature("director") IRQCallback;
 
 //avr_cycle_count_t => uint64_t
 %apply unsigned long long { avr_cycle_count_t }
 %apply unsigned long { uint32_t }
 %apply Pointer NONNULL { avr_t* };
+%apply Pointer NONNULL { avr_irq_t* };
 
 %ignore instance; //LoggerCallback* LoggerCallback::instance 
 
 %include "TimerCallback.h"
 %include "LoggerCallback.h"
+%include "IRQCallback.h"
+
+// *********************************
+// * IRQs                          *
+// *********************************
+%{
+#include "avr_adc.h"
+#include "avr_eeprom.h"
+#include "avr_extint.h"
+#include "avr_flash.h"
+#include "avr_ioport.h"
+#include "avr_spi.h"
+#include "avr_timer.h"
+#include "avr_twi.h"
+#include "avr_uart.h"
+#include "avr_usb.h"
+#include "avr_watchdog.h"
+%}
+
+long AVR_IOCTL_DEF(char, char, char, char);
+%constant long AVR_IOCTL_ADC_GETIRQ;
+%constant long AVR_IOCTL_EEPROM_GET;
+%constant long AVR_IOCTL_EEPROM_SET;
+long AVR_IOCTL_EXTINT_GETIRQ();
+%constant long AVR_IOCTL_FLASH_SPM;
+%constant long AVR_IOCTL_IOPORT_GETIRQ_REGBIT;
+long AVR_IOCTL_IOPORT_GETIRQ(char);
+long AVR_IOCTL_IOPORT_GETSTATE(char);
+long AVR_IOCTL_IOPORT_SET_EXTERNAL(char);
+long AVR_IOCTL_SPI_GETIRQ(char);
+long AVR_IOCTL_TIMER_GETIRQ(char);
+long AVR_IOCTL_TIMER_SET_TRACE(char);
+long AVR_IOCTL_TWI_GETIRQ(char);
+long AVR_IOCTL_UART_GET_FLAGS(char);
+long AVR_IOCTL_UART_GETIRQ(char);
+long AVR_IOCTL_UART_SET_FLAGS(char);
+long AVR_IOCTL_USB_GETIRQ();
+%constant long AVR_IOCTL_USB_READ;
+%constant long AVR_IOCTL_USB_RESET;
+%constant long AVR_IOCTL_USB_SETUP;
+%constant long AVR_IOCTL_USB_VBUS;
+%constant long AVR_IOCTL_USB_WRITE;
+%constant long AVR_IOCTL_WATCHDOG_RESET;
+
+
+
+%include "avr_adc.h"
+%include "avr_eeprom.h"
+%include "avr_extint.h"
+%include "avr_flash.h"
+%include "avr_ioport.h"
+%include "avr_spi.h"
+%include "avr_timer.h"
+%include "avr_twi.h"
+%include "fifo_declare.h"
+%include "avr_uart.h"
+%include "avr_usb.h"
+%include "avr_watchdog.h"

--- a/pysimavr/swig/utils.py
+++ b/pysimavr/swig/utils.py
@@ -167,6 +167,1738 @@ class LoggerCallback(_object):
 LoggerCallback_swigregister = _utils.LoggerCallback_swigregister
 LoggerCallback_swigregister(LoggerCallback)
 
+class IRQCallback(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IRQCallback, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IRQCallback, name)
+    __repr__ = _swig_repr
+
+    def __init__(self, irq):
+        if self.__class__ == IRQCallback:
+            _self = None
+        else:
+            _self = self
+        this = _utils.new_IRQCallback(_self, irq)
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_IRQCallback
+    __del__ = lambda self: None
+
+    def on_notify(self, irq, value):
+        return _utils.IRQCallback_on_notify(self, irq, value)
+
+    def get_irq(self):
+        return _utils.IRQCallback_get_irq(self)
+    def __disown__(self):
+        self.this.disown()
+        _utils.disown_IRQCallback(self)
+        return weakref_proxy(self)
+IRQCallback_swigregister = _utils.IRQCallback_swigregister
+IRQCallback_swigregister(IRQCallback)
+
+
+def AVR_IOCTL_DEF(arg1, arg2, arg3, arg4):
+    return _utils.AVR_IOCTL_DEF(arg1, arg2, arg3, arg4)
+AVR_IOCTL_DEF = _utils.AVR_IOCTL_DEF
+
+_utils.AVR_IOCTL_ADC_GETIRQ_swigconstant(_utils)
+AVR_IOCTL_ADC_GETIRQ = _utils.AVR_IOCTL_ADC_GETIRQ
+
+_utils.AVR_IOCTL_EEPROM_GET_swigconstant(_utils)
+AVR_IOCTL_EEPROM_GET = _utils.AVR_IOCTL_EEPROM_GET
+
+_utils.AVR_IOCTL_EEPROM_SET_swigconstant(_utils)
+AVR_IOCTL_EEPROM_SET = _utils.AVR_IOCTL_EEPROM_SET
+
+def AVR_IOCTL_EXTINT_GETIRQ():
+    return _utils.AVR_IOCTL_EXTINT_GETIRQ()
+AVR_IOCTL_EXTINT_GETIRQ = _utils.AVR_IOCTL_EXTINT_GETIRQ
+
+_utils.AVR_IOCTL_FLASH_SPM_swigconstant(_utils)
+AVR_IOCTL_FLASH_SPM = _utils.AVR_IOCTL_FLASH_SPM
+
+_utils.AVR_IOCTL_IOPORT_GETIRQ_REGBIT_swigconstant(_utils)
+AVR_IOCTL_IOPORT_GETIRQ_REGBIT = _utils.AVR_IOCTL_IOPORT_GETIRQ_REGBIT
+
+def AVR_IOCTL_IOPORT_GETIRQ(arg1):
+    return _utils.AVR_IOCTL_IOPORT_GETIRQ(arg1)
+AVR_IOCTL_IOPORT_GETIRQ = _utils.AVR_IOCTL_IOPORT_GETIRQ
+
+def AVR_IOCTL_IOPORT_GETSTATE(arg1):
+    return _utils.AVR_IOCTL_IOPORT_GETSTATE(arg1)
+AVR_IOCTL_IOPORT_GETSTATE = _utils.AVR_IOCTL_IOPORT_GETSTATE
+
+def AVR_IOCTL_IOPORT_SET_EXTERNAL(arg1):
+    return _utils.AVR_IOCTL_IOPORT_SET_EXTERNAL(arg1)
+AVR_IOCTL_IOPORT_SET_EXTERNAL = _utils.AVR_IOCTL_IOPORT_SET_EXTERNAL
+
+def AVR_IOCTL_SPI_GETIRQ(arg1):
+    return _utils.AVR_IOCTL_SPI_GETIRQ(arg1)
+AVR_IOCTL_SPI_GETIRQ = _utils.AVR_IOCTL_SPI_GETIRQ
+
+def AVR_IOCTL_TIMER_GETIRQ(arg1):
+    return _utils.AVR_IOCTL_TIMER_GETIRQ(arg1)
+AVR_IOCTL_TIMER_GETIRQ = _utils.AVR_IOCTL_TIMER_GETIRQ
+
+def AVR_IOCTL_TIMER_SET_TRACE(arg1):
+    return _utils.AVR_IOCTL_TIMER_SET_TRACE(arg1)
+AVR_IOCTL_TIMER_SET_TRACE = _utils.AVR_IOCTL_TIMER_SET_TRACE
+
+def AVR_IOCTL_TWI_GETIRQ(arg1):
+    return _utils.AVR_IOCTL_TWI_GETIRQ(arg1)
+AVR_IOCTL_TWI_GETIRQ = _utils.AVR_IOCTL_TWI_GETIRQ
+
+def AVR_IOCTL_UART_GET_FLAGS(arg1):
+    return _utils.AVR_IOCTL_UART_GET_FLAGS(arg1)
+AVR_IOCTL_UART_GET_FLAGS = _utils.AVR_IOCTL_UART_GET_FLAGS
+
+def AVR_IOCTL_UART_GETIRQ(arg1):
+    return _utils.AVR_IOCTL_UART_GETIRQ(arg1)
+AVR_IOCTL_UART_GETIRQ = _utils.AVR_IOCTL_UART_GETIRQ
+
+def AVR_IOCTL_UART_SET_FLAGS(arg1):
+    return _utils.AVR_IOCTL_UART_SET_FLAGS(arg1)
+AVR_IOCTL_UART_SET_FLAGS = _utils.AVR_IOCTL_UART_SET_FLAGS
+
+def AVR_IOCTL_USB_GETIRQ():
+    return _utils.AVR_IOCTL_USB_GETIRQ()
+AVR_IOCTL_USB_GETIRQ = _utils.AVR_IOCTL_USB_GETIRQ
+
+_utils.AVR_IOCTL_USB_READ_swigconstant(_utils)
+AVR_IOCTL_USB_READ = _utils.AVR_IOCTL_USB_READ
+
+_utils.AVR_IOCTL_USB_RESET_swigconstant(_utils)
+AVR_IOCTL_USB_RESET = _utils.AVR_IOCTL_USB_RESET
+
+_utils.AVR_IOCTL_USB_SETUP_swigconstant(_utils)
+AVR_IOCTL_USB_SETUP = _utils.AVR_IOCTL_USB_SETUP
+
+_utils.AVR_IOCTL_USB_VBUS_swigconstant(_utils)
+AVR_IOCTL_USB_VBUS = _utils.AVR_IOCTL_USB_VBUS
+
+_utils.AVR_IOCTL_USB_WRITE_swigconstant(_utils)
+AVR_IOCTL_USB_WRITE = _utils.AVR_IOCTL_USB_WRITE
+
+_utils.AVR_IOCTL_WATCHDOG_RESET_swigconstant(_utils)
+AVR_IOCTL_WATCHDOG_RESET = _utils.AVR_IOCTL_WATCHDOG_RESET
+
+_utils.ADC_IRQ_ADC0_swigconstant(_utils)
+ADC_IRQ_ADC0 = _utils.ADC_IRQ_ADC0
+
+_utils.ADC_IRQ_ADC1_swigconstant(_utils)
+ADC_IRQ_ADC1 = _utils.ADC_IRQ_ADC1
+
+_utils.ADC_IRQ_ADC2_swigconstant(_utils)
+ADC_IRQ_ADC2 = _utils.ADC_IRQ_ADC2
+
+_utils.ADC_IRQ_ADC3_swigconstant(_utils)
+ADC_IRQ_ADC3 = _utils.ADC_IRQ_ADC3
+
+_utils.ADC_IRQ_ADC4_swigconstant(_utils)
+ADC_IRQ_ADC4 = _utils.ADC_IRQ_ADC4
+
+_utils.ADC_IRQ_ADC5_swigconstant(_utils)
+ADC_IRQ_ADC5 = _utils.ADC_IRQ_ADC5
+
+_utils.ADC_IRQ_ADC6_swigconstant(_utils)
+ADC_IRQ_ADC6 = _utils.ADC_IRQ_ADC6
+
+_utils.ADC_IRQ_ADC7_swigconstant(_utils)
+ADC_IRQ_ADC7 = _utils.ADC_IRQ_ADC7
+
+_utils.ADC_IRQ_ADC8_swigconstant(_utils)
+ADC_IRQ_ADC8 = _utils.ADC_IRQ_ADC8
+
+_utils.ADC_IRQ_ADC9_swigconstant(_utils)
+ADC_IRQ_ADC9 = _utils.ADC_IRQ_ADC9
+
+_utils.ADC_IRQ_ADC10_swigconstant(_utils)
+ADC_IRQ_ADC10 = _utils.ADC_IRQ_ADC10
+
+_utils.ADC_IRQ_ADC11_swigconstant(_utils)
+ADC_IRQ_ADC11 = _utils.ADC_IRQ_ADC11
+
+_utils.ADC_IRQ_ADC12_swigconstant(_utils)
+ADC_IRQ_ADC12 = _utils.ADC_IRQ_ADC12
+
+_utils.ADC_IRQ_ADC13_swigconstant(_utils)
+ADC_IRQ_ADC13 = _utils.ADC_IRQ_ADC13
+
+_utils.ADC_IRQ_ADC14_swigconstant(_utils)
+ADC_IRQ_ADC14 = _utils.ADC_IRQ_ADC14
+
+_utils.ADC_IRQ_ADC15_swigconstant(_utils)
+ADC_IRQ_ADC15 = _utils.ADC_IRQ_ADC15
+
+_utils.ADC_IRQ_TEMP_swigconstant(_utils)
+ADC_IRQ_TEMP = _utils.ADC_IRQ_TEMP
+
+_utils.ADC_IRQ_IN_TRIGGER_swigconstant(_utils)
+ADC_IRQ_IN_TRIGGER = _utils.ADC_IRQ_IN_TRIGGER
+
+_utils.ADC_IRQ_OUT_TRIGGER_swigconstant(_utils)
+ADC_IRQ_OUT_TRIGGER = _utils.ADC_IRQ_OUT_TRIGGER
+
+_utils.ADC_IRQ_COUNT_swigconstant(_utils)
+ADC_IRQ_COUNT = _utils.ADC_IRQ_COUNT
+
+_utils.ADC_MUX_NONE_swigconstant(_utils)
+ADC_MUX_NONE = _utils.ADC_MUX_NONE
+
+_utils.ADC_MUX_NOISE_swigconstant(_utils)
+ADC_MUX_NOISE = _utils.ADC_MUX_NOISE
+
+_utils.ADC_MUX_SINGLE_swigconstant(_utils)
+ADC_MUX_SINGLE = _utils.ADC_MUX_SINGLE
+
+_utils.ADC_MUX_DIFF_swigconstant(_utils)
+ADC_MUX_DIFF = _utils.ADC_MUX_DIFF
+
+_utils.ADC_MUX_TEMP_swigconstant(_utils)
+ADC_MUX_TEMP = _utils.ADC_MUX_TEMP
+
+_utils.ADC_MUX_REF_swigconstant(_utils)
+ADC_MUX_REF = _utils.ADC_MUX_REF
+
+_utils.ADC_MUX_VCC4_swigconstant(_utils)
+ADC_MUX_VCC4 = _utils.ADC_MUX_VCC4
+class avr_adc_mux_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_adc_mux_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_adc_mux_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["kind"] = _utils.avr_adc_mux_t_kind_set
+    __swig_getmethods__["kind"] = _utils.avr_adc_mux_t_kind_get
+    if _newclass:
+        kind = _swig_property(_utils.avr_adc_mux_t_kind_get, _utils.avr_adc_mux_t_kind_set)
+    __swig_setmethods__["gain"] = _utils.avr_adc_mux_t_gain_set
+    __swig_getmethods__["gain"] = _utils.avr_adc_mux_t_gain_get
+    if _newclass:
+        gain = _swig_property(_utils.avr_adc_mux_t_gain_get, _utils.avr_adc_mux_t_gain_set)
+    __swig_setmethods__["diff"] = _utils.avr_adc_mux_t_diff_set
+    __swig_getmethods__["diff"] = _utils.avr_adc_mux_t_diff_get
+    if _newclass:
+        diff = _swig_property(_utils.avr_adc_mux_t_diff_get, _utils.avr_adc_mux_t_diff_set)
+    __swig_setmethods__["src"] = _utils.avr_adc_mux_t_src_set
+    __swig_getmethods__["src"] = _utils.avr_adc_mux_t_src_get
+    if _newclass:
+        src = _swig_property(_utils.avr_adc_mux_t_src_get, _utils.avr_adc_mux_t_src_set)
+
+    def __init__(self):
+        this = _utils.new_avr_adc_mux_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_adc_mux_t
+    __del__ = lambda self: None
+avr_adc_mux_t_swigregister = _utils.avr_adc_mux_t_swigregister
+avr_adc_mux_t_swigregister(avr_adc_mux_t)
+
+
+_utils.ADC_VREF_AREF_swigconstant(_utils)
+ADC_VREF_AREF = _utils.ADC_VREF_AREF
+
+_utils.ADC_VREF_VCC_swigconstant(_utils)
+ADC_VREF_VCC = _utils.ADC_VREF_VCC
+
+_utils.ADC_VREF_AVCC_swigconstant(_utils)
+ADC_VREF_AVCC = _utils.ADC_VREF_AVCC
+
+_utils.ADC_VREF_V110_swigconstant(_utils)
+ADC_VREF_V110 = _utils.ADC_VREF_V110
+
+_utils.ADC_VREF_V256_swigconstant(_utils)
+ADC_VREF_V256 = _utils.ADC_VREF_V256
+
+_utils.avr_adts_none_swigconstant(_utils)
+avr_adts_none = _utils.avr_adts_none
+
+_utils.avr_adts_free_running_swigconstant(_utils)
+avr_adts_free_running = _utils.avr_adts_free_running
+
+_utils.avr_adts_analog_comparator_0_swigconstant(_utils)
+avr_adts_analog_comparator_0 = _utils.avr_adts_analog_comparator_0
+
+_utils.avr_adts_analog_comparator_1_swigconstant(_utils)
+avr_adts_analog_comparator_1 = _utils.avr_adts_analog_comparator_1
+
+_utils.avr_adts_analog_comparator_2_swigconstant(_utils)
+avr_adts_analog_comparator_2 = _utils.avr_adts_analog_comparator_2
+
+_utils.avr_adts_analog_comparator_3_swigconstant(_utils)
+avr_adts_analog_comparator_3 = _utils.avr_adts_analog_comparator_3
+
+_utils.avr_adts_external_interrupt_0_swigconstant(_utils)
+avr_adts_external_interrupt_0 = _utils.avr_adts_external_interrupt_0
+
+_utils.avr_adts_timer_0_compare_match_a_swigconstant(_utils)
+avr_adts_timer_0_compare_match_a = _utils.avr_adts_timer_0_compare_match_a
+
+_utils.avr_adts_timer_0_compare_match_b_swigconstant(_utils)
+avr_adts_timer_0_compare_match_b = _utils.avr_adts_timer_0_compare_match_b
+
+_utils.avr_adts_timer_0_overflow_swigconstant(_utils)
+avr_adts_timer_0_overflow = _utils.avr_adts_timer_0_overflow
+
+_utils.avr_adts_timer_1_compare_match_b_swigconstant(_utils)
+avr_adts_timer_1_compare_match_b = _utils.avr_adts_timer_1_compare_match_b
+
+_utils.avr_adts_timer_1_overflow_swigconstant(_utils)
+avr_adts_timer_1_overflow = _utils.avr_adts_timer_1_overflow
+
+_utils.avr_adts_timer_1_capture_event_swigconstant(_utils)
+avr_adts_timer_1_capture_event = _utils.avr_adts_timer_1_capture_event
+
+_utils.avr_adts_pin_change_interrupt_swigconstant(_utils)
+avr_adts_pin_change_interrupt = _utils.avr_adts_pin_change_interrupt
+
+_utils.avr_adts_psc_module_0_sync_signal_swigconstant(_utils)
+avr_adts_psc_module_0_sync_signal = _utils.avr_adts_psc_module_0_sync_signal
+
+_utils.avr_adts_psc_module_1_sync_signal_swigconstant(_utils)
+avr_adts_psc_module_1_sync_signal = _utils.avr_adts_psc_module_1_sync_signal
+
+_utils.avr_adts_psc_module_2_sync_signal_swigconstant(_utils)
+avr_adts_psc_module_2_sync_signal = _utils.avr_adts_psc_module_2_sync_signal
+class avr_adc_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_adc_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_adc_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_adc_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_adc_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_adc_t_io_get, _utils.avr_adc_t_io_set)
+    __swig_setmethods__["r_admux"] = _utils.avr_adc_t_r_admux_set
+    __swig_getmethods__["r_admux"] = _utils.avr_adc_t_r_admux_get
+    if _newclass:
+        r_admux = _swig_property(_utils.avr_adc_t_r_admux_get, _utils.avr_adc_t_r_admux_set)
+    __swig_setmethods__["mux"] = _utils.avr_adc_t_mux_set
+    __swig_getmethods__["mux"] = _utils.avr_adc_t_mux_get
+    if _newclass:
+        mux = _swig_property(_utils.avr_adc_t_mux_get, _utils.avr_adc_t_mux_set)
+    __swig_setmethods__["ref"] = _utils.avr_adc_t_ref_set
+    __swig_getmethods__["ref"] = _utils.avr_adc_t_ref_get
+    if _newclass:
+        ref = _swig_property(_utils.avr_adc_t_ref_get, _utils.avr_adc_t_ref_set)
+    __swig_setmethods__["ref_values"] = _utils.avr_adc_t_ref_values_set
+    __swig_getmethods__["ref_values"] = _utils.avr_adc_t_ref_values_get
+    if _newclass:
+        ref_values = _swig_property(_utils.avr_adc_t_ref_values_get, _utils.avr_adc_t_ref_values_set)
+    __swig_setmethods__["adlar"] = _utils.avr_adc_t_adlar_set
+    __swig_getmethods__["adlar"] = _utils.avr_adc_t_adlar_get
+    if _newclass:
+        adlar = _swig_property(_utils.avr_adc_t_adlar_get, _utils.avr_adc_t_adlar_set)
+    __swig_setmethods__["r_adcsra"] = _utils.avr_adc_t_r_adcsra_set
+    __swig_getmethods__["r_adcsra"] = _utils.avr_adc_t_r_adcsra_get
+    if _newclass:
+        r_adcsra = _swig_property(_utils.avr_adc_t_r_adcsra_get, _utils.avr_adc_t_r_adcsra_set)
+    __swig_setmethods__["aden"] = _utils.avr_adc_t_aden_set
+    __swig_getmethods__["aden"] = _utils.avr_adc_t_aden_get
+    if _newclass:
+        aden = _swig_property(_utils.avr_adc_t_aden_get, _utils.avr_adc_t_aden_set)
+    __swig_setmethods__["adsc"] = _utils.avr_adc_t_adsc_set
+    __swig_getmethods__["adsc"] = _utils.avr_adc_t_adsc_get
+    if _newclass:
+        adsc = _swig_property(_utils.avr_adc_t_adsc_get, _utils.avr_adc_t_adsc_set)
+    __swig_setmethods__["adate"] = _utils.avr_adc_t_adate_set
+    __swig_getmethods__["adate"] = _utils.avr_adc_t_adate_get
+    if _newclass:
+        adate = _swig_property(_utils.avr_adc_t_adate_get, _utils.avr_adc_t_adate_set)
+    __swig_setmethods__["adps"] = _utils.avr_adc_t_adps_set
+    __swig_getmethods__["adps"] = _utils.avr_adc_t_adps_get
+    if _newclass:
+        adps = _swig_property(_utils.avr_adc_t_adps_get, _utils.avr_adc_t_adps_set)
+    __swig_setmethods__["r_adcl"] = _utils.avr_adc_t_r_adcl_set
+    __swig_getmethods__["r_adcl"] = _utils.avr_adc_t_r_adcl_get
+    if _newclass:
+        r_adcl = _swig_property(_utils.avr_adc_t_r_adcl_get, _utils.avr_adc_t_r_adcl_set)
+    __swig_setmethods__["r_adch"] = _utils.avr_adc_t_r_adch_set
+    __swig_getmethods__["r_adch"] = _utils.avr_adc_t_r_adch_get
+    if _newclass:
+        r_adch = _swig_property(_utils.avr_adc_t_r_adch_get, _utils.avr_adc_t_r_adch_set)
+    __swig_setmethods__["r_adcsrb"] = _utils.avr_adc_t_r_adcsrb_set
+    __swig_getmethods__["r_adcsrb"] = _utils.avr_adc_t_r_adcsrb_get
+    if _newclass:
+        r_adcsrb = _swig_property(_utils.avr_adc_t_r_adcsrb_get, _utils.avr_adc_t_r_adcsrb_set)
+    __swig_setmethods__["adts"] = _utils.avr_adc_t_adts_set
+    __swig_getmethods__["adts"] = _utils.avr_adc_t_adts_get
+    if _newclass:
+        adts = _swig_property(_utils.avr_adc_t_adts_get, _utils.avr_adc_t_adts_set)
+    __swig_setmethods__["adts_op"] = _utils.avr_adc_t_adts_op_set
+    __swig_getmethods__["adts_op"] = _utils.avr_adc_t_adts_op_get
+    if _newclass:
+        adts_op = _swig_property(_utils.avr_adc_t_adts_op_get, _utils.avr_adc_t_adts_op_set)
+    __swig_setmethods__["adts_mode"] = _utils.avr_adc_t_adts_mode_set
+    __swig_getmethods__["adts_mode"] = _utils.avr_adc_t_adts_mode_get
+    if _newclass:
+        adts_mode = _swig_property(_utils.avr_adc_t_adts_mode_get, _utils.avr_adc_t_adts_mode_set)
+    __swig_setmethods__["bin"] = _utils.avr_adc_t_bin_set
+    __swig_getmethods__["bin"] = _utils.avr_adc_t_bin_get
+    if _newclass:
+        bin = _swig_property(_utils.avr_adc_t_bin_get, _utils.avr_adc_t_bin_set)
+    __swig_setmethods__["ipr"] = _utils.avr_adc_t_ipr_set
+    __swig_getmethods__["ipr"] = _utils.avr_adc_t_ipr_get
+    if _newclass:
+        ipr = _swig_property(_utils.avr_adc_t_ipr_get, _utils.avr_adc_t_ipr_set)
+    __swig_setmethods__["adc"] = _utils.avr_adc_t_adc_set
+    __swig_getmethods__["adc"] = _utils.avr_adc_t_adc_get
+    if _newclass:
+        adc = _swig_property(_utils.avr_adc_t_adc_get, _utils.avr_adc_t_adc_set)
+    __swig_setmethods__["muxmode"] = _utils.avr_adc_t_muxmode_set
+    __swig_getmethods__["muxmode"] = _utils.avr_adc_t_muxmode_get
+    if _newclass:
+        muxmode = _swig_property(_utils.avr_adc_t_muxmode_get, _utils.avr_adc_t_muxmode_set)
+    __swig_setmethods__["adc_values"] = _utils.avr_adc_t_adc_values_set
+    __swig_getmethods__["adc_values"] = _utils.avr_adc_t_adc_values_get
+    if _newclass:
+        adc_values = _swig_property(_utils.avr_adc_t_adc_values_get, _utils.avr_adc_t_adc_values_set)
+    __swig_setmethods__["temp"] = _utils.avr_adc_t_temp_set
+    __swig_getmethods__["temp"] = _utils.avr_adc_t_temp_get
+    if _newclass:
+        temp = _swig_property(_utils.avr_adc_t_temp_get, _utils.avr_adc_t_temp_set)
+    __swig_setmethods__["first"] = _utils.avr_adc_t_first_set
+    __swig_getmethods__["first"] = _utils.avr_adc_t_first_get
+    if _newclass:
+        first = _swig_property(_utils.avr_adc_t_first_get, _utils.avr_adc_t_first_set)
+    __swig_setmethods__["read_status"] = _utils.avr_adc_t_read_status_set
+    __swig_getmethods__["read_status"] = _utils.avr_adc_t_read_status_get
+    if _newclass:
+        read_status = _swig_property(_utils.avr_adc_t_read_status_get, _utils.avr_adc_t_read_status_set)
+
+    def __init__(self):
+        this = _utils.new_avr_adc_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_adc_t
+    __del__ = lambda self: None
+avr_adc_t_swigregister = _utils.avr_adc_t_swigregister
+avr_adc_t_swigregister(avr_adc_t)
+
+
+def avr_adc_init(avr, port):
+    return _utils.avr_adc_init(avr, port)
+avr_adc_init = _utils.avr_adc_init
+class avr_eeprom_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_eeprom_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_eeprom_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_eeprom_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_eeprom_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_eeprom_t_io_get, _utils.avr_eeprom_t_io_set)
+    __swig_setmethods__["eeprom"] = _utils.avr_eeprom_t_eeprom_set
+    __swig_getmethods__["eeprom"] = _utils.avr_eeprom_t_eeprom_get
+    if _newclass:
+        eeprom = _swig_property(_utils.avr_eeprom_t_eeprom_get, _utils.avr_eeprom_t_eeprom_set)
+    __swig_setmethods__["size"] = _utils.avr_eeprom_t_size_set
+    __swig_getmethods__["size"] = _utils.avr_eeprom_t_size_get
+    if _newclass:
+        size = _swig_property(_utils.avr_eeprom_t_size_get, _utils.avr_eeprom_t_size_set)
+    __swig_setmethods__["r_eearh"] = _utils.avr_eeprom_t_r_eearh_set
+    __swig_getmethods__["r_eearh"] = _utils.avr_eeprom_t_r_eearh_get
+    if _newclass:
+        r_eearh = _swig_property(_utils.avr_eeprom_t_r_eearh_get, _utils.avr_eeprom_t_r_eearh_set)
+    __swig_setmethods__["r_eearl"] = _utils.avr_eeprom_t_r_eearl_set
+    __swig_getmethods__["r_eearl"] = _utils.avr_eeprom_t_r_eearl_get
+    if _newclass:
+        r_eearl = _swig_property(_utils.avr_eeprom_t_r_eearl_get, _utils.avr_eeprom_t_r_eearl_set)
+    __swig_setmethods__["r_eedr"] = _utils.avr_eeprom_t_r_eedr_set
+    __swig_getmethods__["r_eedr"] = _utils.avr_eeprom_t_r_eedr_get
+    if _newclass:
+        r_eedr = _swig_property(_utils.avr_eeprom_t_r_eedr_get, _utils.avr_eeprom_t_r_eedr_set)
+    __swig_setmethods__["r_eecr"] = _utils.avr_eeprom_t_r_eecr_set
+    __swig_getmethods__["r_eecr"] = _utils.avr_eeprom_t_r_eecr_get
+    if _newclass:
+        r_eecr = _swig_property(_utils.avr_eeprom_t_r_eecr_get, _utils.avr_eeprom_t_r_eecr_set)
+    __swig_setmethods__["eepm"] = _utils.avr_eeprom_t_eepm_set
+    __swig_getmethods__["eepm"] = _utils.avr_eeprom_t_eepm_get
+    if _newclass:
+        eepm = _swig_property(_utils.avr_eeprom_t_eepm_get, _utils.avr_eeprom_t_eepm_set)
+    __swig_setmethods__["eempe"] = _utils.avr_eeprom_t_eempe_set
+    __swig_getmethods__["eempe"] = _utils.avr_eeprom_t_eempe_get
+    if _newclass:
+        eempe = _swig_property(_utils.avr_eeprom_t_eempe_get, _utils.avr_eeprom_t_eempe_set)
+    __swig_setmethods__["eepe"] = _utils.avr_eeprom_t_eepe_set
+    __swig_getmethods__["eepe"] = _utils.avr_eeprom_t_eepe_get
+    if _newclass:
+        eepe = _swig_property(_utils.avr_eeprom_t_eepe_get, _utils.avr_eeprom_t_eepe_set)
+    __swig_setmethods__["eere"] = _utils.avr_eeprom_t_eere_set
+    __swig_getmethods__["eere"] = _utils.avr_eeprom_t_eere_get
+    if _newclass:
+        eere = _swig_property(_utils.avr_eeprom_t_eere_get, _utils.avr_eeprom_t_eere_set)
+    __swig_setmethods__["ready"] = _utils.avr_eeprom_t_ready_set
+    __swig_getmethods__["ready"] = _utils.avr_eeprom_t_ready_get
+    if _newclass:
+        ready = _swig_property(_utils.avr_eeprom_t_ready_get, _utils.avr_eeprom_t_ready_set)
+
+    def __init__(self):
+        this = _utils.new_avr_eeprom_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_eeprom_t
+    __del__ = lambda self: None
+avr_eeprom_t_swigregister = _utils.avr_eeprom_t_swigregister
+avr_eeprom_t_swigregister(avr_eeprom_t)
+
+
+def avr_eeprom_init(avr, port):
+    return _utils.avr_eeprom_init(avr, port)
+avr_eeprom_init = _utils.avr_eeprom_init
+class avr_eeprom_desc_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_eeprom_desc_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_eeprom_desc_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["ee"] = _utils.avr_eeprom_desc_t_ee_set
+    __swig_getmethods__["ee"] = _utils.avr_eeprom_desc_t_ee_get
+    if _newclass:
+        ee = _swig_property(_utils.avr_eeprom_desc_t_ee_get, _utils.avr_eeprom_desc_t_ee_set)
+    __swig_setmethods__["offset"] = _utils.avr_eeprom_desc_t_offset_set
+    __swig_getmethods__["offset"] = _utils.avr_eeprom_desc_t_offset_get
+    if _newclass:
+        offset = _swig_property(_utils.avr_eeprom_desc_t_offset_get, _utils.avr_eeprom_desc_t_offset_set)
+    __swig_setmethods__["size"] = _utils.avr_eeprom_desc_t_size_set
+    __swig_getmethods__["size"] = _utils.avr_eeprom_desc_t_size_get
+    if _newclass:
+        size = _swig_property(_utils.avr_eeprom_desc_t_size_get, _utils.avr_eeprom_desc_t_size_set)
+
+    def __init__(self):
+        this = _utils.new_avr_eeprom_desc_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_eeprom_desc_t
+    __del__ = lambda self: None
+avr_eeprom_desc_t_swigregister = _utils.avr_eeprom_desc_t_swigregister
+avr_eeprom_desc_t_swigregister(avr_eeprom_desc_t)
+
+
+_utils.EXTINT_IRQ_OUT_INT0_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT0 = _utils.EXTINT_IRQ_OUT_INT0
+
+_utils.EXTINT_IRQ_OUT_INT1_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT1 = _utils.EXTINT_IRQ_OUT_INT1
+
+_utils.EXTINT_IRQ_OUT_INT2_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT2 = _utils.EXTINT_IRQ_OUT_INT2
+
+_utils.EXTINT_IRQ_OUT_INT3_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT3 = _utils.EXTINT_IRQ_OUT_INT3
+
+_utils.EXTINT_IRQ_OUT_INT4_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT4 = _utils.EXTINT_IRQ_OUT_INT4
+
+_utils.EXTINT_IRQ_OUT_INT5_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT5 = _utils.EXTINT_IRQ_OUT_INT5
+
+_utils.EXTINT_IRQ_OUT_INT6_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT6 = _utils.EXTINT_IRQ_OUT_INT6
+
+_utils.EXTINT_IRQ_OUT_INT7_swigconstant(_utils)
+EXTINT_IRQ_OUT_INT7 = _utils.EXTINT_IRQ_OUT_INT7
+
+_utils.EXTINT_COUNT_swigconstant(_utils)
+EXTINT_COUNT = _utils.EXTINT_COUNT
+class avr_extint_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_extint_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_extint_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_extint_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_extint_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_extint_t_io_get, _utils.avr_extint_t_io_set)
+
+    def __init__(self):
+        this = _utils.new_avr_extint_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_extint_t
+    __del__ = lambda self: None
+avr_extint_t_swigregister = _utils.avr_extint_t_swigregister
+avr_extint_t_swigregister(avr_extint_t)
+
+
+def avr_extint_init(avr, p):
+    return _utils.avr_extint_init(avr, p)
+avr_extint_init = _utils.avr_extint_init
+class avr_flash_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_flash_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_flash_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_flash_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_flash_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_flash_t_io_get, _utils.avr_flash_t_io_set)
+    __swig_setmethods__["flags"] = _utils.avr_flash_t_flags_set
+    __swig_getmethods__["flags"] = _utils.avr_flash_t_flags_get
+    if _newclass:
+        flags = _swig_property(_utils.avr_flash_t_flags_get, _utils.avr_flash_t_flags_set)
+    __swig_setmethods__["tmppage"] = _utils.avr_flash_t_tmppage_set
+    __swig_getmethods__["tmppage"] = _utils.avr_flash_t_tmppage_get
+    if _newclass:
+        tmppage = _swig_property(_utils.avr_flash_t_tmppage_get, _utils.avr_flash_t_tmppage_set)
+    __swig_setmethods__["tmppage_used"] = _utils.avr_flash_t_tmppage_used_set
+    __swig_getmethods__["tmppage_used"] = _utils.avr_flash_t_tmppage_used_get
+    if _newclass:
+        tmppage_used = _swig_property(_utils.avr_flash_t_tmppage_used_get, _utils.avr_flash_t_tmppage_used_set)
+    __swig_setmethods__["spm_pagesize"] = _utils.avr_flash_t_spm_pagesize_set
+    __swig_getmethods__["spm_pagesize"] = _utils.avr_flash_t_spm_pagesize_get
+    if _newclass:
+        spm_pagesize = _swig_property(_utils.avr_flash_t_spm_pagesize_get, _utils.avr_flash_t_spm_pagesize_set)
+    __swig_setmethods__["r_spm"] = _utils.avr_flash_t_r_spm_set
+    __swig_getmethods__["r_spm"] = _utils.avr_flash_t_r_spm_get
+    if _newclass:
+        r_spm = _swig_property(_utils.avr_flash_t_r_spm_get, _utils.avr_flash_t_r_spm_set)
+    __swig_setmethods__["selfprgen"] = _utils.avr_flash_t_selfprgen_set
+    __swig_getmethods__["selfprgen"] = _utils.avr_flash_t_selfprgen_get
+    if _newclass:
+        selfprgen = _swig_property(_utils.avr_flash_t_selfprgen_get, _utils.avr_flash_t_selfprgen_set)
+    __swig_setmethods__["pgers"] = _utils.avr_flash_t_pgers_set
+    __swig_getmethods__["pgers"] = _utils.avr_flash_t_pgers_get
+    if _newclass:
+        pgers = _swig_property(_utils.avr_flash_t_pgers_get, _utils.avr_flash_t_pgers_set)
+    __swig_setmethods__["pgwrt"] = _utils.avr_flash_t_pgwrt_set
+    __swig_getmethods__["pgwrt"] = _utils.avr_flash_t_pgwrt_get
+    if _newclass:
+        pgwrt = _swig_property(_utils.avr_flash_t_pgwrt_get, _utils.avr_flash_t_pgwrt_set)
+    __swig_setmethods__["blbset"] = _utils.avr_flash_t_blbset_set
+    __swig_getmethods__["blbset"] = _utils.avr_flash_t_blbset_get
+    if _newclass:
+        blbset = _swig_property(_utils.avr_flash_t_blbset_get, _utils.avr_flash_t_blbset_set)
+    __swig_setmethods__["rwwsre"] = _utils.avr_flash_t_rwwsre_set
+    __swig_getmethods__["rwwsre"] = _utils.avr_flash_t_rwwsre_get
+    if _newclass:
+        rwwsre = _swig_property(_utils.avr_flash_t_rwwsre_get, _utils.avr_flash_t_rwwsre_set)
+    __swig_setmethods__["rwwsb"] = _utils.avr_flash_t_rwwsb_set
+    __swig_getmethods__["rwwsb"] = _utils.avr_flash_t_rwwsb_get
+    if _newclass:
+        rwwsb = _swig_property(_utils.avr_flash_t_rwwsb_get, _utils.avr_flash_t_rwwsb_set)
+    __swig_setmethods__["flash"] = _utils.avr_flash_t_flash_set
+    __swig_getmethods__["flash"] = _utils.avr_flash_t_flash_get
+    if _newclass:
+        flash = _swig_property(_utils.avr_flash_t_flash_get, _utils.avr_flash_t_flash_set)
+
+    def __init__(self):
+        this = _utils.new_avr_flash_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_flash_t
+    __del__ = lambda self: None
+avr_flash_t_swigregister = _utils.avr_flash_t_swigregister
+avr_flash_t_swigregister(avr_flash_t)
+
+
+_utils.AVR_SELFPROG_HAVE_RWW_swigconstant(_utils)
+AVR_SELFPROG_HAVE_RWW = _utils.AVR_SELFPROG_HAVE_RWW
+
+def avr_flash_init(avr, p):
+    return _utils.avr_flash_init(avr, p)
+avr_flash_init = _utils.avr_flash_init
+
+_utils.IOPORT_IRQ_PIN0_swigconstant(_utils)
+IOPORT_IRQ_PIN0 = _utils.IOPORT_IRQ_PIN0
+
+_utils.IOPORT_IRQ_PIN1_swigconstant(_utils)
+IOPORT_IRQ_PIN1 = _utils.IOPORT_IRQ_PIN1
+
+_utils.IOPORT_IRQ_PIN2_swigconstant(_utils)
+IOPORT_IRQ_PIN2 = _utils.IOPORT_IRQ_PIN2
+
+_utils.IOPORT_IRQ_PIN3_swigconstant(_utils)
+IOPORT_IRQ_PIN3 = _utils.IOPORT_IRQ_PIN3
+
+_utils.IOPORT_IRQ_PIN4_swigconstant(_utils)
+IOPORT_IRQ_PIN4 = _utils.IOPORT_IRQ_PIN4
+
+_utils.IOPORT_IRQ_PIN5_swigconstant(_utils)
+IOPORT_IRQ_PIN5 = _utils.IOPORT_IRQ_PIN5
+
+_utils.IOPORT_IRQ_PIN6_swigconstant(_utils)
+IOPORT_IRQ_PIN6 = _utils.IOPORT_IRQ_PIN6
+
+_utils.IOPORT_IRQ_PIN7_swigconstant(_utils)
+IOPORT_IRQ_PIN7 = _utils.IOPORT_IRQ_PIN7
+
+_utils.IOPORT_IRQ_PIN_ALL_swigconstant(_utils)
+IOPORT_IRQ_PIN_ALL = _utils.IOPORT_IRQ_PIN_ALL
+
+_utils.IOPORT_IRQ_DIRECTION_ALL_swigconstant(_utils)
+IOPORT_IRQ_DIRECTION_ALL = _utils.IOPORT_IRQ_DIRECTION_ALL
+
+_utils.IOPORT_IRQ_REG_PORT_swigconstant(_utils)
+IOPORT_IRQ_REG_PORT = _utils.IOPORT_IRQ_REG_PORT
+
+_utils.IOPORT_IRQ_REG_PIN_swigconstant(_utils)
+IOPORT_IRQ_REG_PIN = _utils.IOPORT_IRQ_REG_PIN
+
+_utils.IOPORT_IRQ_COUNT_swigconstant(_utils)
+IOPORT_IRQ_COUNT = _utils.IOPORT_IRQ_COUNT
+
+_utils.AVR_IOPORT_OUTPUT_swigconstant(_utils)
+AVR_IOPORT_OUTPUT = _utils.AVR_IOPORT_OUTPUT
+class avr_ioport_getirq_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_ioport_getirq_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_ioport_getirq_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["bit"] = _utils.avr_ioport_getirq_t_bit_set
+    __swig_getmethods__["bit"] = _utils.avr_ioport_getirq_t_bit_get
+    if _newclass:
+        bit = _swig_property(_utils.avr_ioport_getirq_t_bit_get, _utils.avr_ioport_getirq_t_bit_set)
+    __swig_setmethods__["irq"] = _utils.avr_ioport_getirq_t_irq_set
+    __swig_getmethods__["irq"] = _utils.avr_ioport_getirq_t_irq_get
+    if _newclass:
+        irq = _swig_property(_utils.avr_ioport_getirq_t_irq_get, _utils.avr_ioport_getirq_t_irq_set)
+
+    def __init__(self):
+        this = _utils.new_avr_ioport_getirq_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_ioport_getirq_t
+    __del__ = lambda self: None
+avr_ioport_getirq_t_swigregister = _utils.avr_ioport_getirq_t_swigregister
+avr_ioport_getirq_t_swigregister(avr_ioport_getirq_t)
+
+class avr_ioport_state_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_ioport_state_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_ioport_state_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["name"] = _utils.avr_ioport_state_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_ioport_state_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_ioport_state_t_name_get, _utils.avr_ioport_state_t_name_set)
+    __swig_setmethods__["port"] = _utils.avr_ioport_state_t_port_set
+    __swig_getmethods__["port"] = _utils.avr_ioport_state_t_port_get
+    if _newclass:
+        port = _swig_property(_utils.avr_ioport_state_t_port_get, _utils.avr_ioport_state_t_port_set)
+    __swig_setmethods__["ddr"] = _utils.avr_ioport_state_t_ddr_set
+    __swig_getmethods__["ddr"] = _utils.avr_ioport_state_t_ddr_get
+    if _newclass:
+        ddr = _swig_property(_utils.avr_ioport_state_t_ddr_get, _utils.avr_ioport_state_t_ddr_set)
+    __swig_setmethods__["pin"] = _utils.avr_ioport_state_t_pin_set
+    __swig_getmethods__["pin"] = _utils.avr_ioport_state_t_pin_get
+    if _newclass:
+        pin = _swig_property(_utils.avr_ioport_state_t_pin_get, _utils.avr_ioport_state_t_pin_set)
+
+    def __init__(self):
+        this = _utils.new_avr_ioport_state_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_ioport_state_t
+    __del__ = lambda self: None
+avr_ioport_state_t_swigregister = _utils.avr_ioport_state_t_swigregister
+avr_ioport_state_t_swigregister(avr_ioport_state_t)
+
+class avr_ioport_external_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_ioport_external_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_ioport_external_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["name"] = _utils.avr_ioport_external_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_ioport_external_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_ioport_external_t_name_get, _utils.avr_ioport_external_t_name_set)
+    __swig_setmethods__["mask"] = _utils.avr_ioport_external_t_mask_set
+    __swig_getmethods__["mask"] = _utils.avr_ioport_external_t_mask_get
+    if _newclass:
+        mask = _swig_property(_utils.avr_ioport_external_t_mask_get, _utils.avr_ioport_external_t_mask_set)
+    __swig_setmethods__["value"] = _utils.avr_ioport_external_t_value_set
+    __swig_getmethods__["value"] = _utils.avr_ioport_external_t_value_get
+    if _newclass:
+        value = _swig_property(_utils.avr_ioport_external_t_value_get, _utils.avr_ioport_external_t_value_set)
+
+    def __init__(self):
+        this = _utils.new_avr_ioport_external_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_ioport_external_t
+    __del__ = lambda self: None
+avr_ioport_external_t_swigregister = _utils.avr_ioport_external_t_swigregister
+avr_ioport_external_t_swigregister(avr_ioport_external_t)
+
+class avr_iopin_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_iopin_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_iopin_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["port"] = _utils.avr_iopin_t_port_set
+    __swig_getmethods__["port"] = _utils.avr_iopin_t_port_get
+    if _newclass:
+        port = _swig_property(_utils.avr_iopin_t_port_get, _utils.avr_iopin_t_port_set)
+    __swig_setmethods__["pin"] = _utils.avr_iopin_t_pin_set
+    __swig_getmethods__["pin"] = _utils.avr_iopin_t_pin_get
+    if _newclass:
+        pin = _swig_property(_utils.avr_iopin_t_pin_get, _utils.avr_iopin_t_pin_set)
+
+    def __init__(self):
+        this = _utils.new_avr_iopin_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_iopin_t
+    __del__ = lambda self: None
+avr_iopin_t_swigregister = _utils.avr_iopin_t_swigregister
+avr_iopin_t_swigregister(avr_iopin_t)
+
+class avr_ioport_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_ioport_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_ioport_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_ioport_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_ioport_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_ioport_t_io_get, _utils.avr_ioport_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_ioport_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_ioport_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_ioport_t_name_get, _utils.avr_ioport_t_name_set)
+    __swig_setmethods__["r_port"] = _utils.avr_ioport_t_r_port_set
+    __swig_getmethods__["r_port"] = _utils.avr_ioport_t_r_port_get
+    if _newclass:
+        r_port = _swig_property(_utils.avr_ioport_t_r_port_get, _utils.avr_ioport_t_r_port_set)
+    __swig_setmethods__["r_ddr"] = _utils.avr_ioport_t_r_ddr_set
+    __swig_getmethods__["r_ddr"] = _utils.avr_ioport_t_r_ddr_get
+    if _newclass:
+        r_ddr = _swig_property(_utils.avr_ioport_t_r_ddr_get, _utils.avr_ioport_t_r_ddr_set)
+    __swig_setmethods__["r_pin"] = _utils.avr_ioport_t_r_pin_set
+    __swig_getmethods__["r_pin"] = _utils.avr_ioport_t_r_pin_get
+    if _newclass:
+        r_pin = _swig_property(_utils.avr_ioport_t_r_pin_get, _utils.avr_ioport_t_r_pin_set)
+    __swig_setmethods__["pcint"] = _utils.avr_ioport_t_pcint_set
+    __swig_getmethods__["pcint"] = _utils.avr_ioport_t_pcint_get
+    if _newclass:
+        pcint = _swig_property(_utils.avr_ioport_t_pcint_get, _utils.avr_ioport_t_pcint_set)
+    __swig_setmethods__["r_pcint"] = _utils.avr_ioport_t_r_pcint_set
+    __swig_getmethods__["r_pcint"] = _utils.avr_ioport_t_r_pcint_get
+    if _newclass:
+        r_pcint = _swig_property(_utils.avr_ioport_t_r_pcint_get, _utils.avr_ioport_t_r_pcint_set)
+
+    def __init__(self):
+        this = _utils.new_avr_ioport_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_ioport_t
+    __del__ = lambda self: None
+avr_ioport_t_swigregister = _utils.avr_ioport_t_swigregister
+avr_ioport_t_swigregister(avr_ioport_t)
+
+
+def avr_ioport_init(avr, port):
+    return _utils.avr_ioport_init(avr, port)
+avr_ioport_init = _utils.avr_ioport_init
+
+_utils.SPI_IRQ_INPUT_swigconstant(_utils)
+SPI_IRQ_INPUT = _utils.SPI_IRQ_INPUT
+
+_utils.SPI_IRQ_OUTPUT_swigconstant(_utils)
+SPI_IRQ_OUTPUT = _utils.SPI_IRQ_OUTPUT
+
+_utils.SPI_IRQ_COUNT_swigconstant(_utils)
+SPI_IRQ_COUNT = _utils.SPI_IRQ_COUNT
+class avr_spi_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_spi_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_spi_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_spi_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_spi_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_spi_t_io_get, _utils.avr_spi_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_spi_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_spi_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_spi_t_name_get, _utils.avr_spi_t_name_set)
+    __swig_setmethods__["disabled"] = _utils.avr_spi_t_disabled_set
+    __swig_getmethods__["disabled"] = _utils.avr_spi_t_disabled_get
+    if _newclass:
+        disabled = _swig_property(_utils.avr_spi_t_disabled_get, _utils.avr_spi_t_disabled_set)
+    __swig_setmethods__["r_spdr"] = _utils.avr_spi_t_r_spdr_set
+    __swig_getmethods__["r_spdr"] = _utils.avr_spi_t_r_spdr_get
+    if _newclass:
+        r_spdr = _swig_property(_utils.avr_spi_t_r_spdr_get, _utils.avr_spi_t_r_spdr_set)
+    __swig_setmethods__["r_spcr"] = _utils.avr_spi_t_r_spcr_set
+    __swig_getmethods__["r_spcr"] = _utils.avr_spi_t_r_spcr_get
+    if _newclass:
+        r_spcr = _swig_property(_utils.avr_spi_t_r_spcr_get, _utils.avr_spi_t_r_spcr_set)
+    __swig_setmethods__["r_spsr"] = _utils.avr_spi_t_r_spsr_set
+    __swig_getmethods__["r_spsr"] = _utils.avr_spi_t_r_spsr_get
+    if _newclass:
+        r_spsr = _swig_property(_utils.avr_spi_t_r_spsr_get, _utils.avr_spi_t_r_spsr_set)
+    __swig_setmethods__["spe"] = _utils.avr_spi_t_spe_set
+    __swig_getmethods__["spe"] = _utils.avr_spi_t_spe_get
+    if _newclass:
+        spe = _swig_property(_utils.avr_spi_t_spe_get, _utils.avr_spi_t_spe_set)
+    __swig_setmethods__["mstr"] = _utils.avr_spi_t_mstr_set
+    __swig_getmethods__["mstr"] = _utils.avr_spi_t_mstr_get
+    if _newclass:
+        mstr = _swig_property(_utils.avr_spi_t_mstr_get, _utils.avr_spi_t_mstr_set)
+    __swig_setmethods__["spr"] = _utils.avr_spi_t_spr_set
+    __swig_getmethods__["spr"] = _utils.avr_spi_t_spr_get
+    if _newclass:
+        spr = _swig_property(_utils.avr_spi_t_spr_get, _utils.avr_spi_t_spr_set)
+    __swig_setmethods__["spi"] = _utils.avr_spi_t_spi_set
+    __swig_getmethods__["spi"] = _utils.avr_spi_t_spi_get
+    if _newclass:
+        spi = _swig_property(_utils.avr_spi_t_spi_get, _utils.avr_spi_t_spi_set)
+    __swig_setmethods__["input_data_register"] = _utils.avr_spi_t_input_data_register_set
+    __swig_getmethods__["input_data_register"] = _utils.avr_spi_t_input_data_register_get
+    if _newclass:
+        input_data_register = _swig_property(_utils.avr_spi_t_input_data_register_get, _utils.avr_spi_t_input_data_register_set)
+
+    def __init__(self):
+        this = _utils.new_avr_spi_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_spi_t
+    __del__ = lambda self: None
+avr_spi_t_swigregister = _utils.avr_spi_t_swigregister
+avr_spi_t_swigregister(avr_spi_t)
+
+
+def avr_spi_init(avr, port):
+    return _utils.avr_spi_init(avr, port)
+avr_spi_init = _utils.avr_spi_init
+
+_utils.AVR_TIMER_COMPA_swigconstant(_utils)
+AVR_TIMER_COMPA = _utils.AVR_TIMER_COMPA
+
+_utils.AVR_TIMER_COMPB_swigconstant(_utils)
+AVR_TIMER_COMPB = _utils.AVR_TIMER_COMPB
+
+_utils.AVR_TIMER_COMPC_swigconstant(_utils)
+AVR_TIMER_COMPC = _utils.AVR_TIMER_COMPC
+
+_utils.AVR_TIMER_COMP_COUNT_swigconstant(_utils)
+AVR_TIMER_COMP_COUNT = _utils.AVR_TIMER_COMP_COUNT
+
+_utils.TIMER_IRQ_OUT_PWM0_swigconstant(_utils)
+TIMER_IRQ_OUT_PWM0 = _utils.TIMER_IRQ_OUT_PWM0
+
+_utils.TIMER_IRQ_OUT_PWM1_swigconstant(_utils)
+TIMER_IRQ_OUT_PWM1 = _utils.TIMER_IRQ_OUT_PWM1
+
+_utils.TIMER_IRQ_OUT_COMP_swigconstant(_utils)
+TIMER_IRQ_OUT_COMP = _utils.TIMER_IRQ_OUT_COMP
+
+_utils.TIMER_IRQ_COUNT_swigconstant(_utils)
+TIMER_IRQ_COUNT = _utils.TIMER_IRQ_COUNT
+
+_utils.avr_timer_wgm_none_swigconstant(_utils)
+avr_timer_wgm_none = _utils.avr_timer_wgm_none
+
+_utils.avr_timer_wgm_normal_swigconstant(_utils)
+avr_timer_wgm_normal = _utils.avr_timer_wgm_normal
+
+_utils.avr_timer_wgm_ctc_swigconstant(_utils)
+avr_timer_wgm_ctc = _utils.avr_timer_wgm_ctc
+
+_utils.avr_timer_wgm_pwm_swigconstant(_utils)
+avr_timer_wgm_pwm = _utils.avr_timer_wgm_pwm
+
+_utils.avr_timer_wgm_fast_pwm_swigconstant(_utils)
+avr_timer_wgm_fast_pwm = _utils.avr_timer_wgm_fast_pwm
+
+_utils.avr_timer_wgm_fc_pwm_swigconstant(_utils)
+avr_timer_wgm_fc_pwm = _utils.avr_timer_wgm_fc_pwm
+
+_utils.avr_timer_com_normal_swigconstant(_utils)
+avr_timer_com_normal = _utils.avr_timer_com_normal
+
+_utils.avr_timer_com_toggle_swigconstant(_utils)
+avr_timer_com_toggle = _utils.avr_timer_com_toggle
+
+_utils.avr_timer_com_clear_swigconstant(_utils)
+avr_timer_com_clear = _utils.avr_timer_com_clear
+
+_utils.avr_timer_com_set_swigconstant(_utils)
+avr_timer_com_set = _utils.avr_timer_com_set
+
+_utils.avr_timer_wgm_reg_constant_swigconstant(_utils)
+avr_timer_wgm_reg_constant = _utils.avr_timer_wgm_reg_constant
+
+_utils.avr_timer_wgm_reg_ocra_swigconstant(_utils)
+avr_timer_wgm_reg_ocra = _utils.avr_timer_wgm_reg_ocra
+
+_utils.avr_timer_wgm_reg_icr_swigconstant(_utils)
+avr_timer_wgm_reg_icr = _utils.avr_timer_wgm_reg_icr
+class avr_timer_wgm_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_timer_wgm_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_timer_wgm_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["top"] = _utils.avr_timer_wgm_t_top_set
+    __swig_getmethods__["top"] = _utils.avr_timer_wgm_t_top_get
+    if _newclass:
+        top = _swig_property(_utils.avr_timer_wgm_t_top_get, _utils.avr_timer_wgm_t_top_set)
+    __swig_setmethods__["bottom"] = _utils.avr_timer_wgm_t_bottom_set
+    __swig_getmethods__["bottom"] = _utils.avr_timer_wgm_t_bottom_get
+    if _newclass:
+        bottom = _swig_property(_utils.avr_timer_wgm_t_bottom_get, _utils.avr_timer_wgm_t_bottom_set)
+    __swig_setmethods__["size"] = _utils.avr_timer_wgm_t_size_set
+    __swig_getmethods__["size"] = _utils.avr_timer_wgm_t_size_get
+    if _newclass:
+        size = _swig_property(_utils.avr_timer_wgm_t_size_get, _utils.avr_timer_wgm_t_size_set)
+    __swig_setmethods__["kind"] = _utils.avr_timer_wgm_t_kind_set
+    __swig_getmethods__["kind"] = _utils.avr_timer_wgm_t_kind_get
+    if _newclass:
+        kind = _swig_property(_utils.avr_timer_wgm_t_kind_get, _utils.avr_timer_wgm_t_kind_set)
+
+    def __init__(self):
+        this = _utils.new_avr_timer_wgm_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_timer_wgm_t
+    __del__ = lambda self: None
+avr_timer_wgm_t_swigregister = _utils.avr_timer_wgm_t_swigregister
+avr_timer_wgm_t_swigregister(avr_timer_wgm_t)
+
+class avr_timer_comp_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_timer_comp_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_timer_comp_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["interrupt"] = _utils.avr_timer_comp_t_interrupt_set
+    __swig_getmethods__["interrupt"] = _utils.avr_timer_comp_t_interrupt_get
+    if _newclass:
+        interrupt = _swig_property(_utils.avr_timer_comp_t_interrupt_get, _utils.avr_timer_comp_t_interrupt_set)
+    __swig_setmethods__["timer"] = _utils.avr_timer_comp_t_timer_set
+    __swig_getmethods__["timer"] = _utils.avr_timer_comp_t_timer_get
+    if _newclass:
+        timer = _swig_property(_utils.avr_timer_comp_t_timer_get, _utils.avr_timer_comp_t_timer_set)
+    __swig_setmethods__["r_ocr"] = _utils.avr_timer_comp_t_r_ocr_set
+    __swig_getmethods__["r_ocr"] = _utils.avr_timer_comp_t_r_ocr_get
+    if _newclass:
+        r_ocr = _swig_property(_utils.avr_timer_comp_t_r_ocr_get, _utils.avr_timer_comp_t_r_ocr_set)
+    __swig_setmethods__["r_ocrh"] = _utils.avr_timer_comp_t_r_ocrh_set
+    __swig_getmethods__["r_ocrh"] = _utils.avr_timer_comp_t_r_ocrh_get
+    if _newclass:
+        r_ocrh = _swig_property(_utils.avr_timer_comp_t_r_ocrh_get, _utils.avr_timer_comp_t_r_ocrh_set)
+    __swig_setmethods__["com"] = _utils.avr_timer_comp_t_com_set
+    __swig_getmethods__["com"] = _utils.avr_timer_comp_t_com_get
+    if _newclass:
+        com = _swig_property(_utils.avr_timer_comp_t_com_get, _utils.avr_timer_comp_t_com_set)
+    __swig_setmethods__["com_pin"] = _utils.avr_timer_comp_t_com_pin_set
+    __swig_getmethods__["com_pin"] = _utils.avr_timer_comp_t_com_pin_get
+    if _newclass:
+        com_pin = _swig_property(_utils.avr_timer_comp_t_com_pin_get, _utils.avr_timer_comp_t_com_pin_set)
+    __swig_setmethods__["comp_cycles"] = _utils.avr_timer_comp_t_comp_cycles_set
+    __swig_getmethods__["comp_cycles"] = _utils.avr_timer_comp_t_comp_cycles_get
+    if _newclass:
+        comp_cycles = _swig_property(_utils.avr_timer_comp_t_comp_cycles_get, _utils.avr_timer_comp_t_comp_cycles_set)
+
+    def __init__(self):
+        this = _utils.new_avr_timer_comp_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_timer_comp_t
+    __del__ = lambda self: None
+avr_timer_comp_t_swigregister = _utils.avr_timer_comp_t_swigregister
+avr_timer_comp_t_swigregister(avr_timer_comp_t)
+
+
+_utils.avr_timer_trace_ocr_swigconstant(_utils)
+avr_timer_trace_ocr = _utils.avr_timer_trace_ocr
+
+_utils.avr_timer_trace_tcnt_swigconstant(_utils)
+avr_timer_trace_tcnt = _utils.avr_timer_trace_tcnt
+
+_utils.avr_timer_trace_compa_swigconstant(_utils)
+avr_timer_trace_compa = _utils.avr_timer_trace_compa
+
+_utils.avr_timer_trace_compb_swigconstant(_utils)
+avr_timer_trace_compb = _utils.avr_timer_trace_compb
+
+_utils.avr_timer_trace_compc_swigconstant(_utils)
+avr_timer_trace_compc = _utils.avr_timer_trace_compc
+class avr_timer_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_timer_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_timer_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_timer_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_timer_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_timer_t_io_get, _utils.avr_timer_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_timer_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_timer_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_timer_t_name_get, _utils.avr_timer_t_name_set)
+    __swig_setmethods__["trace"] = _utils.avr_timer_t_trace_set
+    __swig_getmethods__["trace"] = _utils.avr_timer_t_trace_get
+    if _newclass:
+        trace = _swig_property(_utils.avr_timer_t_trace_get, _utils.avr_timer_t_trace_set)
+    __swig_setmethods__["disabled"] = _utils.avr_timer_t_disabled_set
+    __swig_getmethods__["disabled"] = _utils.avr_timer_t_disabled_get
+    if _newclass:
+        disabled = _swig_property(_utils.avr_timer_t_disabled_get, _utils.avr_timer_t_disabled_set)
+    __swig_setmethods__["r_tcnt"] = _utils.avr_timer_t_r_tcnt_set
+    __swig_getmethods__["r_tcnt"] = _utils.avr_timer_t_r_tcnt_get
+    if _newclass:
+        r_tcnt = _swig_property(_utils.avr_timer_t_r_tcnt_get, _utils.avr_timer_t_r_tcnt_set)
+    __swig_setmethods__["r_icr"] = _utils.avr_timer_t_r_icr_set
+    __swig_getmethods__["r_icr"] = _utils.avr_timer_t_r_icr_get
+    if _newclass:
+        r_icr = _swig_property(_utils.avr_timer_t_r_icr_get, _utils.avr_timer_t_r_icr_set)
+    __swig_setmethods__["r_tcnth"] = _utils.avr_timer_t_r_tcnth_set
+    __swig_getmethods__["r_tcnth"] = _utils.avr_timer_t_r_tcnth_get
+    if _newclass:
+        r_tcnth = _swig_property(_utils.avr_timer_t_r_tcnth_get, _utils.avr_timer_t_r_tcnth_set)
+    __swig_setmethods__["r_icrh"] = _utils.avr_timer_t_r_icrh_set
+    __swig_getmethods__["r_icrh"] = _utils.avr_timer_t_r_icrh_get
+    if _newclass:
+        r_icrh = _swig_property(_utils.avr_timer_t_r_icrh_get, _utils.avr_timer_t_r_icrh_set)
+    __swig_setmethods__["wgm"] = _utils.avr_timer_t_wgm_set
+    __swig_getmethods__["wgm"] = _utils.avr_timer_t_wgm_get
+    if _newclass:
+        wgm = _swig_property(_utils.avr_timer_t_wgm_get, _utils.avr_timer_t_wgm_set)
+    __swig_setmethods__["wgm_op"] = _utils.avr_timer_t_wgm_op_set
+    __swig_getmethods__["wgm_op"] = _utils.avr_timer_t_wgm_op_get
+    if _newclass:
+        wgm_op = _swig_property(_utils.avr_timer_t_wgm_op_get, _utils.avr_timer_t_wgm_op_set)
+    __swig_setmethods__["mode"] = _utils.avr_timer_t_mode_set
+    __swig_getmethods__["mode"] = _utils.avr_timer_t_mode_get
+    if _newclass:
+        mode = _swig_property(_utils.avr_timer_t_mode_get, _utils.avr_timer_t_mode_set)
+    __swig_setmethods__["wgm_op_mode_kind"] = _utils.avr_timer_t_wgm_op_mode_kind_set
+    __swig_getmethods__["wgm_op_mode_kind"] = _utils.avr_timer_t_wgm_op_mode_kind_get
+    if _newclass:
+        wgm_op_mode_kind = _swig_property(_utils.avr_timer_t_wgm_op_mode_kind_get, _utils.avr_timer_t_wgm_op_mode_kind_set)
+    __swig_setmethods__["wgm_op_mode_size"] = _utils.avr_timer_t_wgm_op_mode_size_set
+    __swig_getmethods__["wgm_op_mode_size"] = _utils.avr_timer_t_wgm_op_mode_size_get
+    if _newclass:
+        wgm_op_mode_size = _swig_property(_utils.avr_timer_t_wgm_op_mode_size_get, _utils.avr_timer_t_wgm_op_mode_size_set)
+    __swig_setmethods__["as2"] = _utils.avr_timer_t_as2_set
+    __swig_getmethods__["as2"] = _utils.avr_timer_t_as2_get
+    if _newclass:
+        as2 = _swig_property(_utils.avr_timer_t_as2_get, _utils.avr_timer_t_as2_set)
+    __swig_setmethods__["cs"] = _utils.avr_timer_t_cs_set
+    __swig_getmethods__["cs"] = _utils.avr_timer_t_cs_get
+    if _newclass:
+        cs = _swig_property(_utils.avr_timer_t_cs_get, _utils.avr_timer_t_cs_set)
+    __swig_setmethods__["cs_div"] = _utils.avr_timer_t_cs_div_set
+    __swig_getmethods__["cs_div"] = _utils.avr_timer_t_cs_div_get
+    if _newclass:
+        cs_div = _swig_property(_utils.avr_timer_t_cs_div_get, _utils.avr_timer_t_cs_div_set)
+    __swig_setmethods__["cs_div_clock"] = _utils.avr_timer_t_cs_div_clock_set
+    __swig_getmethods__["cs_div_clock"] = _utils.avr_timer_t_cs_div_clock_get
+    if _newclass:
+        cs_div_clock = _swig_property(_utils.avr_timer_t_cs_div_clock_get, _utils.avr_timer_t_cs_div_clock_set)
+    __swig_setmethods__["icp"] = _utils.avr_timer_t_icp_set
+    __swig_getmethods__["icp"] = _utils.avr_timer_t_icp_get
+    if _newclass:
+        icp = _swig_property(_utils.avr_timer_t_icp_get, _utils.avr_timer_t_icp_set)
+    __swig_setmethods__["ices"] = _utils.avr_timer_t_ices_set
+    __swig_getmethods__["ices"] = _utils.avr_timer_t_ices_get
+    if _newclass:
+        ices = _swig_property(_utils.avr_timer_t_ices_get, _utils.avr_timer_t_ices_set)
+    __swig_setmethods__["comp"] = _utils.avr_timer_t_comp_set
+    __swig_getmethods__["comp"] = _utils.avr_timer_t_comp_get
+    if _newclass:
+        comp = _swig_property(_utils.avr_timer_t_comp_get, _utils.avr_timer_t_comp_set)
+    __swig_setmethods__["overflow"] = _utils.avr_timer_t_overflow_set
+    __swig_getmethods__["overflow"] = _utils.avr_timer_t_overflow_get
+    if _newclass:
+        overflow = _swig_property(_utils.avr_timer_t_overflow_get, _utils.avr_timer_t_overflow_set)
+    __swig_setmethods__["icr"] = _utils.avr_timer_t_icr_set
+    __swig_getmethods__["icr"] = _utils.avr_timer_t_icr_get
+    if _newclass:
+        icr = _swig_property(_utils.avr_timer_t_icr_get, _utils.avr_timer_t_icr_set)
+    __swig_setmethods__["tov_cycles"] = _utils.avr_timer_t_tov_cycles_set
+    __swig_getmethods__["tov_cycles"] = _utils.avr_timer_t_tov_cycles_get
+    if _newclass:
+        tov_cycles = _swig_property(_utils.avr_timer_t_tov_cycles_get, _utils.avr_timer_t_tov_cycles_set)
+    __swig_setmethods__["tov_base"] = _utils.avr_timer_t_tov_base_set
+    __swig_getmethods__["tov_base"] = _utils.avr_timer_t_tov_base_get
+    if _newclass:
+        tov_base = _swig_property(_utils.avr_timer_t_tov_base_get, _utils.avr_timer_t_tov_base_set)
+    __swig_setmethods__["tov_top"] = _utils.avr_timer_t_tov_top_set
+    __swig_getmethods__["tov_top"] = _utils.avr_timer_t_tov_top_get
+    if _newclass:
+        tov_top = _swig_property(_utils.avr_timer_t_tov_top_get, _utils.avr_timer_t_tov_top_set)
+
+    def __init__(self):
+        this = _utils.new_avr_timer_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_timer_t
+    __del__ = lambda self: None
+avr_timer_t_swigregister = _utils.avr_timer_t_swigregister
+avr_timer_t_swigregister(avr_timer_t)
+
+
+def avr_timer_init(avr, port):
+    return _utils.avr_timer_init(avr, port)
+avr_timer_init = _utils.avr_timer_init
+
+_utils.TWI_IRQ_INPUT_swigconstant(_utils)
+TWI_IRQ_INPUT = _utils.TWI_IRQ_INPUT
+
+_utils.TWI_IRQ_OUTPUT_swigconstant(_utils)
+TWI_IRQ_OUTPUT = _utils.TWI_IRQ_OUTPUT
+
+_utils.TWI_IRQ_STATUS_swigconstant(_utils)
+TWI_IRQ_STATUS = _utils.TWI_IRQ_STATUS
+
+_utils.TWI_IRQ_COUNT_swigconstant(_utils)
+TWI_IRQ_COUNT = _utils.TWI_IRQ_COUNT
+
+_utils.TWI_COND_START_swigconstant(_utils)
+TWI_COND_START = _utils.TWI_COND_START
+
+_utils.TWI_COND_STOP_swigconstant(_utils)
+TWI_COND_STOP = _utils.TWI_COND_STOP
+
+_utils.TWI_COND_ADDR_swigconstant(_utils)
+TWI_COND_ADDR = _utils.TWI_COND_ADDR
+
+_utils.TWI_COND_ACK_swigconstant(_utils)
+TWI_COND_ACK = _utils.TWI_COND_ACK
+
+_utils.TWI_COND_WRITE_swigconstant(_utils)
+TWI_COND_WRITE = _utils.TWI_COND_WRITE
+
+_utils.TWI_COND_READ_swigconstant(_utils)
+TWI_COND_READ = _utils.TWI_COND_READ
+
+_utils.TWI_COND_SLAVE_swigconstant(_utils)
+TWI_COND_SLAVE = _utils.TWI_COND_SLAVE
+class avr_twi_msg_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_twi_msg_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_twi_msg_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["unused"] = _utils.avr_twi_msg_t_unused_set
+    __swig_getmethods__["unused"] = _utils.avr_twi_msg_t_unused_get
+    if _newclass:
+        unused = _swig_property(_utils.avr_twi_msg_t_unused_get, _utils.avr_twi_msg_t_unused_set)
+    __swig_setmethods__["msg"] = _utils.avr_twi_msg_t_msg_set
+    __swig_getmethods__["msg"] = _utils.avr_twi_msg_t_msg_get
+    if _newclass:
+        msg = _swig_property(_utils.avr_twi_msg_t_msg_get, _utils.avr_twi_msg_t_msg_set)
+    __swig_setmethods__["addr"] = _utils.avr_twi_msg_t_addr_set
+    __swig_getmethods__["addr"] = _utils.avr_twi_msg_t_addr_get
+    if _newclass:
+        addr = _swig_property(_utils.avr_twi_msg_t_addr_get, _utils.avr_twi_msg_t_addr_set)
+    __swig_setmethods__["data"] = _utils.avr_twi_msg_t_data_set
+    __swig_getmethods__["data"] = _utils.avr_twi_msg_t_data_get
+    if _newclass:
+        data = _swig_property(_utils.avr_twi_msg_t_data_get, _utils.avr_twi_msg_t_data_set)
+
+    def __init__(self):
+        this = _utils.new_avr_twi_msg_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_twi_msg_t
+    __del__ = lambda self: None
+avr_twi_msg_t_swigregister = _utils.avr_twi_msg_t_swigregister
+avr_twi_msg_t_swigregister(avr_twi_msg_t)
+
+class avr_twi_msg_irq_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_twi_msg_irq_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_twi_msg_irq_t, name)
+    __repr__ = _swig_repr
+
+    def __init__(self):
+        this = _utils.new_avr_twi_msg_irq_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_twi_msg_irq_t
+    __del__ = lambda self: None
+avr_twi_msg_irq_t_swigregister = _utils.avr_twi_msg_irq_t_swigregister
+avr_twi_msg_irq_t_swigregister(avr_twi_msg_irq_t)
+
+class avr_twi_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_twi_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_twi_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_twi_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_twi_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_twi_t_io_get, _utils.avr_twi_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_twi_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_twi_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_twi_t_name_get, _utils.avr_twi_t_name_set)
+    __swig_setmethods__["disabled"] = _utils.avr_twi_t_disabled_set
+    __swig_getmethods__["disabled"] = _utils.avr_twi_t_disabled_get
+    if _newclass:
+        disabled = _swig_property(_utils.avr_twi_t_disabled_get, _utils.avr_twi_t_disabled_set)
+    __swig_setmethods__["r_twbr"] = _utils.avr_twi_t_r_twbr_set
+    __swig_getmethods__["r_twbr"] = _utils.avr_twi_t_r_twbr_get
+    if _newclass:
+        r_twbr = _swig_property(_utils.avr_twi_t_r_twbr_get, _utils.avr_twi_t_r_twbr_set)
+    __swig_setmethods__["r_twcr"] = _utils.avr_twi_t_r_twcr_set
+    __swig_getmethods__["r_twcr"] = _utils.avr_twi_t_r_twcr_get
+    if _newclass:
+        r_twcr = _swig_property(_utils.avr_twi_t_r_twcr_get, _utils.avr_twi_t_r_twcr_set)
+    __swig_setmethods__["r_twsr"] = _utils.avr_twi_t_r_twsr_set
+    __swig_getmethods__["r_twsr"] = _utils.avr_twi_t_r_twsr_get
+    if _newclass:
+        r_twsr = _swig_property(_utils.avr_twi_t_r_twsr_get, _utils.avr_twi_t_r_twsr_set)
+    __swig_setmethods__["r_twar"] = _utils.avr_twi_t_r_twar_set
+    __swig_getmethods__["r_twar"] = _utils.avr_twi_t_r_twar_get
+    if _newclass:
+        r_twar = _swig_property(_utils.avr_twi_t_r_twar_get, _utils.avr_twi_t_r_twar_set)
+    __swig_setmethods__["r_twamr"] = _utils.avr_twi_t_r_twamr_set
+    __swig_getmethods__["r_twamr"] = _utils.avr_twi_t_r_twamr_get
+    if _newclass:
+        r_twamr = _swig_property(_utils.avr_twi_t_r_twamr_get, _utils.avr_twi_t_r_twamr_set)
+    __swig_setmethods__["r_twdr"] = _utils.avr_twi_t_r_twdr_set
+    __swig_getmethods__["r_twdr"] = _utils.avr_twi_t_r_twdr_get
+    if _newclass:
+        r_twdr = _swig_property(_utils.avr_twi_t_r_twdr_get, _utils.avr_twi_t_r_twdr_set)
+    __swig_setmethods__["twen"] = _utils.avr_twi_t_twen_set
+    __swig_getmethods__["twen"] = _utils.avr_twi_t_twen_get
+    if _newclass:
+        twen = _swig_property(_utils.avr_twi_t_twen_get, _utils.avr_twi_t_twen_set)
+    __swig_setmethods__["twea"] = _utils.avr_twi_t_twea_set
+    __swig_getmethods__["twea"] = _utils.avr_twi_t_twea_get
+    if _newclass:
+        twea = _swig_property(_utils.avr_twi_t_twea_get, _utils.avr_twi_t_twea_set)
+    __swig_setmethods__["twsta"] = _utils.avr_twi_t_twsta_set
+    __swig_getmethods__["twsta"] = _utils.avr_twi_t_twsta_get
+    if _newclass:
+        twsta = _swig_property(_utils.avr_twi_t_twsta_get, _utils.avr_twi_t_twsta_set)
+    __swig_setmethods__["twsto"] = _utils.avr_twi_t_twsto_set
+    __swig_getmethods__["twsto"] = _utils.avr_twi_t_twsto_get
+    if _newclass:
+        twsto = _swig_property(_utils.avr_twi_t_twsto_get, _utils.avr_twi_t_twsto_set)
+    __swig_setmethods__["twwc"] = _utils.avr_twi_t_twwc_set
+    __swig_getmethods__["twwc"] = _utils.avr_twi_t_twwc_get
+    if _newclass:
+        twwc = _swig_property(_utils.avr_twi_t_twwc_get, _utils.avr_twi_t_twwc_set)
+    __swig_setmethods__["twsr"] = _utils.avr_twi_t_twsr_set
+    __swig_getmethods__["twsr"] = _utils.avr_twi_t_twsr_get
+    if _newclass:
+        twsr = _swig_property(_utils.avr_twi_t_twsr_get, _utils.avr_twi_t_twsr_set)
+    __swig_setmethods__["twps"] = _utils.avr_twi_t_twps_set
+    __swig_getmethods__["twps"] = _utils.avr_twi_t_twps_get
+    if _newclass:
+        twps = _swig_property(_utils.avr_twi_t_twps_get, _utils.avr_twi_t_twps_set)
+    __swig_setmethods__["twi"] = _utils.avr_twi_t_twi_set
+    __swig_getmethods__["twi"] = _utils.avr_twi_t_twi_get
+    if _newclass:
+        twi = _swig_property(_utils.avr_twi_t_twi_get, _utils.avr_twi_t_twi_set)
+    __swig_setmethods__["state"] = _utils.avr_twi_t_state_set
+    __swig_getmethods__["state"] = _utils.avr_twi_t_state_get
+    if _newclass:
+        state = _swig_property(_utils.avr_twi_t_state_get, _utils.avr_twi_t_state_set)
+    __swig_setmethods__["peer_addr"] = _utils.avr_twi_t_peer_addr_set
+    __swig_getmethods__["peer_addr"] = _utils.avr_twi_t_peer_addr_get
+    if _newclass:
+        peer_addr = _swig_property(_utils.avr_twi_t_peer_addr_get, _utils.avr_twi_t_peer_addr_set)
+    __swig_setmethods__["next_twstate"] = _utils.avr_twi_t_next_twstate_set
+    __swig_getmethods__["next_twstate"] = _utils.avr_twi_t_next_twstate_get
+    if _newclass:
+        next_twstate = _swig_property(_utils.avr_twi_t_next_twstate_get, _utils.avr_twi_t_next_twstate_set)
+
+    def __init__(self):
+        this = _utils.new_avr_twi_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_twi_t
+    __del__ = lambda self: None
+avr_twi_t_swigregister = _utils.avr_twi_t_swigregister
+avr_twi_t_swigregister(avr_twi_t)
+
+
+def avr_twi_init(avr, port):
+    return _utils.avr_twi_init(avr, port)
+avr_twi_init = _utils.avr_twi_init
+
+def avr_twi_irq_msg(msg, addr, data):
+    return _utils.avr_twi_irq_msg(msg, addr, data)
+avr_twi_irq_msg = _utils.avr_twi_irq_msg
+
+_utils.uart_fifo_overflow_f_swigconstant(_utils)
+uart_fifo_overflow_f = _utils.uart_fifo_overflow_f
+
+_utils.uart_fifo_fifo_size_swigconstant(_utils)
+uart_fifo_fifo_size = _utils.uart_fifo_fifo_size
+class uart_fifo_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, uart_fifo_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, uart_fifo_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["buffer"] = _utils.uart_fifo_t_buffer_set
+    __swig_getmethods__["buffer"] = _utils.uart_fifo_t_buffer_get
+    if _newclass:
+        buffer = _swig_property(_utils.uart_fifo_t_buffer_get, _utils.uart_fifo_t_buffer_set)
+    __swig_setmethods__["read"] = _utils.uart_fifo_t_read_set
+    __swig_getmethods__["read"] = _utils.uart_fifo_t_read_get
+    if _newclass:
+        read = _swig_property(_utils.uart_fifo_t_read_get, _utils.uart_fifo_t_read_set)
+    __swig_setmethods__["write"] = _utils.uart_fifo_t_write_set
+    __swig_getmethods__["write"] = _utils.uart_fifo_t_write_get
+    if _newclass:
+        write = _swig_property(_utils.uart_fifo_t_write_get, _utils.uart_fifo_t_write_set)
+    __swig_setmethods__["flags"] = _utils.uart_fifo_t_flags_set
+    __swig_getmethods__["flags"] = _utils.uart_fifo_t_flags_get
+    if _newclass:
+        flags = _swig_property(_utils.uart_fifo_t_flags_get, _utils.uart_fifo_t_flags_set)
+
+    def __init__(self):
+        this = _utils.new_uart_fifo_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_uart_fifo_t
+    __del__ = lambda self: None
+uart_fifo_t_swigregister = _utils.uart_fifo_t_swigregister
+uart_fifo_t_swigregister(uart_fifo_t)
+
+
+_utils.UART_IRQ_INPUT_swigconstant(_utils)
+UART_IRQ_INPUT = _utils.UART_IRQ_INPUT
+
+_utils.UART_IRQ_OUTPUT_swigconstant(_utils)
+UART_IRQ_OUTPUT = _utils.UART_IRQ_OUTPUT
+
+_utils.UART_IRQ_OUT_XON_swigconstant(_utils)
+UART_IRQ_OUT_XON = _utils.UART_IRQ_OUT_XON
+
+_utils.UART_IRQ_OUT_XOFF_swigconstant(_utils)
+UART_IRQ_OUT_XOFF = _utils.UART_IRQ_OUT_XOFF
+
+_utils.UART_IRQ_COUNT_swigconstant(_utils)
+UART_IRQ_COUNT = _utils.UART_IRQ_COUNT
+
+_utils.AVR_UART_FLAG_POOL_SLEEP_swigconstant(_utils)
+AVR_UART_FLAG_POOL_SLEEP = _utils.AVR_UART_FLAG_POOL_SLEEP
+
+_utils.AVR_UART_FLAG_STDIO_swigconstant(_utils)
+AVR_UART_FLAG_STDIO = _utils.AVR_UART_FLAG_STDIO
+class avr_uart_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_uart_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_uart_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_uart_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_uart_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_uart_t_io_get, _utils.avr_uart_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_uart_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_uart_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_uart_t_name_get, _utils.avr_uart_t_name_set)
+    __swig_setmethods__["disabled"] = _utils.avr_uart_t_disabled_set
+    __swig_getmethods__["disabled"] = _utils.avr_uart_t_disabled_get
+    if _newclass:
+        disabled = _swig_property(_utils.avr_uart_t_disabled_get, _utils.avr_uart_t_disabled_set)
+    __swig_setmethods__["r_udr"] = _utils.avr_uart_t_r_udr_set
+    __swig_getmethods__["r_udr"] = _utils.avr_uart_t_r_udr_get
+    if _newclass:
+        r_udr = _swig_property(_utils.avr_uart_t_r_udr_get, _utils.avr_uart_t_r_udr_set)
+    __swig_setmethods__["r_ucsra"] = _utils.avr_uart_t_r_ucsra_set
+    __swig_getmethods__["r_ucsra"] = _utils.avr_uart_t_r_ucsra_get
+    if _newclass:
+        r_ucsra = _swig_property(_utils.avr_uart_t_r_ucsra_get, _utils.avr_uart_t_r_ucsra_set)
+    __swig_setmethods__["r_ucsrb"] = _utils.avr_uart_t_r_ucsrb_set
+    __swig_getmethods__["r_ucsrb"] = _utils.avr_uart_t_r_ucsrb_get
+    if _newclass:
+        r_ucsrb = _swig_property(_utils.avr_uart_t_r_ucsrb_get, _utils.avr_uart_t_r_ucsrb_set)
+    __swig_setmethods__["r_ucsrc"] = _utils.avr_uart_t_r_ucsrc_set
+    __swig_getmethods__["r_ucsrc"] = _utils.avr_uart_t_r_ucsrc_get
+    if _newclass:
+        r_ucsrc = _swig_property(_utils.avr_uart_t_r_ucsrc_get, _utils.avr_uart_t_r_ucsrc_set)
+    __swig_setmethods__["rxen"] = _utils.avr_uart_t_rxen_set
+    __swig_getmethods__["rxen"] = _utils.avr_uart_t_rxen_get
+    if _newclass:
+        rxen = _swig_property(_utils.avr_uart_t_rxen_get, _utils.avr_uart_t_rxen_set)
+    __swig_setmethods__["txen"] = _utils.avr_uart_t_txen_set
+    __swig_getmethods__["txen"] = _utils.avr_uart_t_txen_get
+    if _newclass:
+        txen = _swig_property(_utils.avr_uart_t_txen_get, _utils.avr_uart_t_txen_set)
+    __swig_setmethods__["u2x"] = _utils.avr_uart_t_u2x_set
+    __swig_getmethods__["u2x"] = _utils.avr_uart_t_u2x_get
+    if _newclass:
+        u2x = _swig_property(_utils.avr_uart_t_u2x_get, _utils.avr_uart_t_u2x_set)
+    __swig_setmethods__["usbs"] = _utils.avr_uart_t_usbs_set
+    __swig_getmethods__["usbs"] = _utils.avr_uart_t_usbs_get
+    if _newclass:
+        usbs = _swig_property(_utils.avr_uart_t_usbs_get, _utils.avr_uart_t_usbs_set)
+    __swig_setmethods__["ucsz"] = _utils.avr_uart_t_ucsz_set
+    __swig_getmethods__["ucsz"] = _utils.avr_uart_t_ucsz_get
+    if _newclass:
+        ucsz = _swig_property(_utils.avr_uart_t_ucsz_get, _utils.avr_uart_t_ucsz_set)
+    __swig_setmethods__["ucsz2"] = _utils.avr_uart_t_ucsz2_set
+    __swig_getmethods__["ucsz2"] = _utils.avr_uart_t_ucsz2_get
+    if _newclass:
+        ucsz2 = _swig_property(_utils.avr_uart_t_ucsz2_get, _utils.avr_uart_t_ucsz2_set)
+    __swig_setmethods__["r_ubrrl"] = _utils.avr_uart_t_r_ubrrl_set
+    __swig_getmethods__["r_ubrrl"] = _utils.avr_uart_t_r_ubrrl_get
+    if _newclass:
+        r_ubrrl = _swig_property(_utils.avr_uart_t_r_ubrrl_get, _utils.avr_uart_t_r_ubrrl_set)
+    __swig_setmethods__["r_ubrrh"] = _utils.avr_uart_t_r_ubrrh_set
+    __swig_getmethods__["r_ubrrh"] = _utils.avr_uart_t_r_ubrrh_get
+    if _newclass:
+        r_ubrrh = _swig_property(_utils.avr_uart_t_r_ubrrh_get, _utils.avr_uart_t_r_ubrrh_set)
+    __swig_setmethods__["rxc"] = _utils.avr_uart_t_rxc_set
+    __swig_getmethods__["rxc"] = _utils.avr_uart_t_rxc_get
+    if _newclass:
+        rxc = _swig_property(_utils.avr_uart_t_rxc_get, _utils.avr_uart_t_rxc_set)
+    __swig_setmethods__["txc"] = _utils.avr_uart_t_txc_set
+    __swig_getmethods__["txc"] = _utils.avr_uart_t_txc_get
+    if _newclass:
+        txc = _swig_property(_utils.avr_uart_t_txc_get, _utils.avr_uart_t_txc_set)
+    __swig_setmethods__["udrc"] = _utils.avr_uart_t_udrc_set
+    __swig_getmethods__["udrc"] = _utils.avr_uart_t_udrc_get
+    if _newclass:
+        udrc = _swig_property(_utils.avr_uart_t_udrc_get, _utils.avr_uart_t_udrc_set)
+    __swig_setmethods__["input"] = _utils.avr_uart_t_input_set
+    __swig_getmethods__["input"] = _utils.avr_uart_t_input_get
+    if _newclass:
+        input = _swig_property(_utils.avr_uart_t_input_get, _utils.avr_uart_t_input_set)
+    __swig_setmethods__["flags"] = _utils.avr_uart_t_flags_set
+    __swig_getmethods__["flags"] = _utils.avr_uart_t_flags_get
+    if _newclass:
+        flags = _swig_property(_utils.avr_uart_t_flags_get, _utils.avr_uart_t_flags_set)
+    __swig_setmethods__["usec_per_byte"] = _utils.avr_uart_t_usec_per_byte_set
+    __swig_getmethods__["usec_per_byte"] = _utils.avr_uart_t_usec_per_byte_get
+    if _newclass:
+        usec_per_byte = _swig_property(_utils.avr_uart_t_usec_per_byte_get, _utils.avr_uart_t_usec_per_byte_set)
+    __swig_setmethods__["stdio_out"] = _utils.avr_uart_t_stdio_out_set
+    __swig_getmethods__["stdio_out"] = _utils.avr_uart_t_stdio_out_get
+    if _newclass:
+        stdio_out = _swig_property(_utils.avr_uart_t_stdio_out_get, _utils.avr_uart_t_stdio_out_set)
+    __swig_setmethods__["stdio_len"] = _utils.avr_uart_t_stdio_len_set
+    __swig_getmethods__["stdio_len"] = _utils.avr_uart_t_stdio_len_get
+    if _newclass:
+        stdio_len = _swig_property(_utils.avr_uart_t_stdio_len_get, _utils.avr_uart_t_stdio_len_set)
+
+    def __init__(self):
+        this = _utils.new_avr_uart_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_uart_t
+    __del__ = lambda self: None
+avr_uart_t_swigregister = _utils.avr_uart_t_swigregister
+avr_uart_t_swigregister(avr_uart_t)
+
+
+def avr_uart_init(avr, port):
+    return _utils.avr_uart_init(avr, port)
+avr_uart_init = _utils.avr_uart_init
+
+_utils.USB_IRQ_ATTACH_swigconstant(_utils)
+USB_IRQ_ATTACH = _utils.USB_IRQ_ATTACH
+
+_utils.USB_IRQ_COUNT_swigconstant(_utils)
+USB_IRQ_COUNT = _utils.USB_IRQ_COUNT
+class avr_io_usb(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_io_usb, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_io_usb, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["pipe"] = _utils.avr_io_usb_pipe_set
+    __swig_getmethods__["pipe"] = _utils.avr_io_usb_pipe_get
+    if _newclass:
+        pipe = _swig_property(_utils.avr_io_usb_pipe_get, _utils.avr_io_usb_pipe_set)
+    __swig_setmethods__["sz"] = _utils.avr_io_usb_sz_set
+    __swig_getmethods__["sz"] = _utils.avr_io_usb_sz_get
+    if _newclass:
+        sz = _swig_property(_utils.avr_io_usb_sz_get, _utils.avr_io_usb_sz_set)
+    __swig_setmethods__["buf"] = _utils.avr_io_usb_buf_set
+    __swig_getmethods__["buf"] = _utils.avr_io_usb_buf_get
+    if _newclass:
+        buf = _swig_property(_utils.avr_io_usb_buf_get, _utils.avr_io_usb_buf_set)
+
+    def __init__(self):
+        this = _utils.new_avr_io_usb()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_io_usb
+    __del__ = lambda self: None
+avr_io_usb_swigregister = _utils.avr_io_usb_swigregister
+avr_io_usb_swigregister(avr_io_usb)
+
+
+_utils.AVR_IOCTL_USB_NAK_swigconstant(_utils)
+AVR_IOCTL_USB_NAK = _utils.AVR_IOCTL_USB_NAK
+
+_utils.AVR_IOCTL_USB_STALL_swigconstant(_utils)
+AVR_IOCTL_USB_STALL = _utils.AVR_IOCTL_USB_STALL
+
+_utils.AVR_IOCTL_USB_OK_swigconstant(_utils)
+AVR_IOCTL_USB_OK = _utils.AVR_IOCTL_USB_OK
+class avr_usb_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_usb_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_usb_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_usb_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_usb_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_usb_t_io_get, _utils.avr_usb_t_io_set)
+    __swig_setmethods__["name"] = _utils.avr_usb_t_name_set
+    __swig_getmethods__["name"] = _utils.avr_usb_t_name_get
+    if _newclass:
+        name = _swig_property(_utils.avr_usb_t_name_get, _utils.avr_usb_t_name_set)
+    __swig_setmethods__["disabled"] = _utils.avr_usb_t_disabled_set
+    __swig_getmethods__["disabled"] = _utils.avr_usb_t_disabled_get
+    if _newclass:
+        disabled = _swig_property(_utils.avr_usb_t_disabled_get, _utils.avr_usb_t_disabled_set)
+    __swig_setmethods__["usbrf"] = _utils.avr_usb_t_usbrf_set
+    __swig_getmethods__["usbrf"] = _utils.avr_usb_t_usbrf_get
+    if _newclass:
+        usbrf = _swig_property(_utils.avr_usb_t_usbrf_get, _utils.avr_usb_t_usbrf_set)
+    __swig_setmethods__["r_usbcon"] = _utils.avr_usb_t_r_usbcon_set
+    __swig_getmethods__["r_usbcon"] = _utils.avr_usb_t_r_usbcon_get
+    if _newclass:
+        r_usbcon = _swig_property(_utils.avr_usb_t_r_usbcon_get, _utils.avr_usb_t_r_usbcon_set)
+    __swig_setmethods__["r_pllcsr"] = _utils.avr_usb_t_r_pllcsr_set
+    __swig_getmethods__["r_pllcsr"] = _utils.avr_usb_t_r_pllcsr_get
+    if _newclass:
+        r_pllcsr = _swig_property(_utils.avr_usb_t_r_pllcsr_get, _utils.avr_usb_t_r_pllcsr_set)
+    __swig_setmethods__["usb_com_vect"] = _utils.avr_usb_t_usb_com_vect_set
+    __swig_getmethods__["usb_com_vect"] = _utils.avr_usb_t_usb_com_vect_get
+    if _newclass:
+        usb_com_vect = _swig_property(_utils.avr_usb_t_usb_com_vect_get, _utils.avr_usb_t_usb_com_vect_set)
+    __swig_setmethods__["usb_gen_vect"] = _utils.avr_usb_t_usb_gen_vect_set
+    __swig_getmethods__["usb_gen_vect"] = _utils.avr_usb_t_usb_gen_vect_get
+    if _newclass:
+        usb_gen_vect = _swig_property(_utils.avr_usb_t_usb_gen_vect_get, _utils.avr_usb_t_usb_gen_vect_set)
+    __swig_setmethods__["state"] = _utils.avr_usb_t_state_set
+    __swig_getmethods__["state"] = _utils.avr_usb_t_state_get
+    if _newclass:
+        state = _swig_property(_utils.avr_usb_t_state_get, _utils.avr_usb_t_state_set)
+
+    def __init__(self):
+        this = _utils.new_avr_usb_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_usb_t
+    __del__ = lambda self: None
+avr_usb_t_swigregister = _utils.avr_usb_t_swigregister
+avr_usb_t_swigregister(avr_usb_t)
+
+
+def avr_usb_init(avr, port):
+    return _utils.avr_usb_init(avr, port)
+avr_usb_init = _utils.avr_usb_init
+class avr_watchdog_t(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, avr_watchdog_t, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, avr_watchdog_t, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["io"] = _utils.avr_watchdog_t_io_set
+    __swig_getmethods__["io"] = _utils.avr_watchdog_t_io_get
+    if _newclass:
+        io = _swig_property(_utils.avr_watchdog_t_io_get, _utils.avr_watchdog_t_io_set)
+    __swig_setmethods__["wdrf"] = _utils.avr_watchdog_t_wdrf_set
+    __swig_getmethods__["wdrf"] = _utils.avr_watchdog_t_wdrf_get
+    if _newclass:
+        wdrf = _swig_property(_utils.avr_watchdog_t_wdrf_get, _utils.avr_watchdog_t_wdrf_set)
+    __swig_setmethods__["wdce"] = _utils.avr_watchdog_t_wdce_set
+    __swig_getmethods__["wdce"] = _utils.avr_watchdog_t_wdce_get
+    if _newclass:
+        wdce = _swig_property(_utils.avr_watchdog_t_wdce_get, _utils.avr_watchdog_t_wdce_set)
+    __swig_setmethods__["wde"] = _utils.avr_watchdog_t_wde_set
+    __swig_getmethods__["wde"] = _utils.avr_watchdog_t_wde_get
+    if _newclass:
+        wde = _swig_property(_utils.avr_watchdog_t_wde_get, _utils.avr_watchdog_t_wde_set)
+    __swig_setmethods__["wdp"] = _utils.avr_watchdog_t_wdp_set
+    __swig_getmethods__["wdp"] = _utils.avr_watchdog_t_wdp_get
+    if _newclass:
+        wdp = _swig_property(_utils.avr_watchdog_t_wdp_get, _utils.avr_watchdog_t_wdp_set)
+    __swig_setmethods__["watchdog"] = _utils.avr_watchdog_t_watchdog_set
+    __swig_getmethods__["watchdog"] = _utils.avr_watchdog_t_watchdog_get
+    if _newclass:
+        watchdog = _swig_property(_utils.avr_watchdog_t_watchdog_get, _utils.avr_watchdog_t_watchdog_set)
+    __swig_setmethods__["cycle_count"] = _utils.avr_watchdog_t_cycle_count_set
+    __swig_getmethods__["cycle_count"] = _utils.avr_watchdog_t_cycle_count_get
+    if _newclass:
+        cycle_count = _swig_property(_utils.avr_watchdog_t_cycle_count_get, _utils.avr_watchdog_t_cycle_count_set)
+
+    def __init__(self):
+        this = _utils.new_avr_watchdog_t()
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _utils.delete_avr_watchdog_t
+    __del__ = lambda self: None
+avr_watchdog_t_swigregister = _utils.avr_watchdog_t_swigregister
+avr_watchdog_t_swigregister(avr_watchdog_t)
+
+
+def avr_watchdog_init(avr, p):
+    return _utils.avr_watchdog_init(avr, p)
+avr_watchdog_init = _utils.avr_watchdog_init
 # This file is compatible with both classic and new-style classes.
 
 

--- a/pysimavr/swig/utils/IRQCallback.cpp
+++ b/pysimavr/swig/utils/IRQCallback.cpp
@@ -1,0 +1,45 @@
+/*
+ * IRQCallback.cpp
+ *
+ *  Created on: Mar 8, 2017
+ *      Author: premik
+ */
+
+#include "IRQCallback.h"
+#include "sim_irq.h"
+#include <stdexcept>
+
+
+//#include <iostream>
+
+
+/*
+* Connection between the simavr c callback to the c++ object. The C++ instance is being passed using the generic param argument.
+*/
+static void _IRQ_callback(struct avr_irq_t * irq, uint32_t value, void * param) {
+	//std::cout << "Callback " << std::endl;
+	IRQCallback* cb = (IRQCallback*) param;
+	cb->on_notify(irq, value);
+}
+
+IRQCallback::IRQCallback(struct avr_irq_t* irq) {
+	this->irq = irq;
+	avr_irq_register_notify(irq, _IRQ_callback, this);
+}
+
+struct avr_irq_t* IRQCallback::get_irq() {
+	return this->irq;
+}
+
+IRQCallback::~IRQCallback() {
+	//std::cout << "Destructor " << std::endl;
+	avr_irq_unregister_notify(this->irq, _IRQ_callback, this);
+}
+
+
+void IRQCallback::on_notify(struct avr_irq_t* irq, uint32_t value) {
+	//When used a pure virtual somehow it is not possible to init the class from python.
+	//As the swig wrapper still thinks the class is abstract despite it was extended from python. 
+	throw std::runtime_error("Virtual method on_notify is not implemented.");
+	//std::cout << "Not implemented" << std::endl;
+}

--- a/pysimavr/swig/utils/IRQCallback.h
+++ b/pysimavr/swig/utils/IRQCallback.h
@@ -1,0 +1,31 @@
+/*
+ * IRQCallback.h
+ *
+ *  Created on: Mar 8, 2017
+ *      Author: premik
+ */
+
+#ifndef UTILS_IRQCALLBACK_H_
+#define UTILS_IRQCALLBACK_H_
+
+#include "sim_irq.h"
+
+
+/*
+ * Enables IRQ notification function to be used with python method.
+ * The simavr IRQs is a mean to register and propagate events among simavr components.
+ *
+ */
+class IRQCallback {
+public:
+	IRQCallback(struct avr_irq_t* irq);
+	virtual ~IRQCallback();
+	virtual void on_notify(struct avr_irq_t* irq, uint32_t value);//Implement this one in Pyhton class.
+	struct avr_irq_t* get_irq();
+
+protected:
+	struct avr_irq_t* irq;
+
+};
+
+#endif /* UTILS_IRQCALLBACK_H_ */

--- a/pysimavr/swig/utils_wrap.cc
+++ b/pysimavr/swig/utils_wrap.cc
@@ -3455,12 +3455,47 @@ namespace Swig {
 
 /* -------- TYPES TABLE (BEGIN) -------- */
 
-#define SWIGTYPE_p_LoggerCallback swig_types[0]
-#define SWIGTYPE_p_TimerCallback swig_types[1]
-#define SWIGTYPE_p_avr_t swig_types[2]
-#define SWIGTYPE_p_char swig_types[3]
-static swig_type_info *swig_types[5];
-static swig_module_info swig_module = {swig_types, 4, 0, 0, 0, 0};
+#define SWIGTYPE_p_IRQCallback swig_types[0]
+#define SWIGTYPE_p_LoggerCallback swig_types[1]
+#define SWIGTYPE_p_TimerCallback swig_types[2]
+#define SWIGTYPE_p_avr_adc_mux_t swig_types[3]
+#define SWIGTYPE_p_avr_adc_t swig_types[4]
+#define SWIGTYPE_p_avr_adts_type swig_types[5]
+#define SWIGTYPE_p_avr_eeprom_desc_t swig_types[6]
+#define SWIGTYPE_p_avr_eeprom_t swig_types[7]
+#define SWIGTYPE_p_avr_extint_t swig_types[8]
+#define SWIGTYPE_p_avr_flash_t swig_types[9]
+#define SWIGTYPE_p_avr_int_vector_t swig_types[10]
+#define SWIGTYPE_p_avr_io_addr_t swig_types[11]
+#define SWIGTYPE_p_avr_io_t swig_types[12]
+#define SWIGTYPE_p_avr_io_usb swig_types[13]
+#define SWIGTYPE_p_avr_iopin_t swig_types[14]
+#define SWIGTYPE_p_avr_ioport_external_t swig_types[15]
+#define SWIGTYPE_p_avr_ioport_getirq_t swig_types[16]
+#define SWIGTYPE_p_avr_ioport_state_t swig_types[17]
+#define SWIGTYPE_p_avr_ioport_t swig_types[18]
+#define SWIGTYPE_p_avr_irq_t swig_types[19]
+#define SWIGTYPE_p_avr_regbit_t swig_types[20]
+#define SWIGTYPE_p_avr_spi_t swig_types[21]
+#define SWIGTYPE_p_avr_t swig_types[22]
+#define SWIGTYPE_p_avr_timer_comp_t swig_types[23]
+#define SWIGTYPE_p_avr_timer_t swig_types[24]
+#define SWIGTYPE_p_avr_timer_wgm_t swig_types[25]
+#define SWIGTYPE_p_avr_twi_msg_irq_t swig_types[26]
+#define SWIGTYPE_p_avr_twi_msg_t swig_types[27]
+#define SWIGTYPE_p_avr_twi_t swig_types[28]
+#define SWIGTYPE_p_avr_uart_t swig_types[29]
+#define SWIGTYPE_p_avr_usb_t swig_types[30]
+#define SWIGTYPE_p_avr_watchdog_t swig_types[31]
+#define SWIGTYPE_p_char swig_types[32]
+#define SWIGTYPE_p_p_avr_irq_t swig_types[33]
+#define SWIGTYPE_p_uart_fifo_t swig_types[34]
+#define SWIGTYPE_p_uint16_t swig_types[35]
+#define SWIGTYPE_p_uint64_t swig_types[36]
+#define SWIGTYPE_p_uint8_t swig_types[37]
+#define SWIGTYPE_p_usb_internal_state swig_types[38]
+static swig_type_info *swig_types[40];
+static swig_module_info swig_module = {swig_types, 39, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3567,7 +3602,7 @@ namespace swig {
 
 #include "TimerCallback.h"
 #include "LoggerCallback.h"
-
+#include "IRQCallback.h"
 
 
 SWIGINTERN int
@@ -3979,6 +4014,78 @@ SWIGINTERNINLINE PyObject*
 }
 
 
+SWIGINTERNINLINE PyObject* 
+SWIG_From_unsigned_SS_long  (unsigned long value)
+{
+  return (value > LONG_MAX) ?
+    PyLong_FromUnsignedLong(value) : PyLong_FromLong(static_cast< long >(value)); 
+}
+
+
+#include "avr_adc.h"
+#include "avr_eeprom.h"
+#include "avr_extint.h"
+#include "avr_flash.h"
+#include "avr_ioport.h"
+#include "avr_spi.h"
+#include "avr_timer.h"
+#include "avr_twi.h"
+#include "avr_uart.h"
+#include "avr_usb.h"
+#include "avr_watchdog.h"
+
+
+SWIGINTERN int
+SWIG_AsCharArray(PyObject * obj, char *val, size_t size)
+{ 
+  char* cptr = 0; size_t csize = 0; int alloc = SWIG_OLDOBJ;
+  int res = SWIG_AsCharPtrAndSize(obj, &cptr, &csize, &alloc);
+  if (SWIG_IsOK(res)) {
+    /* special case of single char conversion when we don't need space for NUL */
+    if (size == 1 && csize == 2 && cptr && !cptr[1]) --csize;
+    if (csize <= size) {
+      if (val) {
+	if (csize) memcpy(val, cptr, csize*sizeof(char));
+	if (csize < size) memset(val + csize, 0, (size - csize)*sizeof(char));
+      }
+      if (alloc == SWIG_NEWOBJ) {
+	delete[] cptr;
+	res = SWIG_DelNewMask(res);
+      }      
+      return res;
+    }
+    if (alloc == SWIG_NEWOBJ) delete[] cptr;
+  }
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_char (PyObject * obj, char *val)
+{    
+  int res = SWIG_AsCharArray(obj, val, 1);
+  if (!SWIG_IsOK(res)) {
+    long v;
+    res = SWIG_AddCast(SWIG_AsVal_long (obj, &v));
+    if (SWIG_IsOK(res)) {
+      if ((CHAR_MIN <= v) && (v <= CHAR_MAX)) {
+	if (val) *val = static_cast< char >(v);
+      } else {
+	res = SWIG_OverflowError;
+      }
+    }
+  }
+  return res;
+}
+
+
+SWIGINTERNINLINE PyObject *
+SWIG_From_char  (char c) 
+{ 
+  return SWIG_FromCharPtrAndSize(&c,1);
+}
+
+
 
 /* ---------------------------------------------------
  * C++ director class methods
@@ -4063,6 +4170,45 @@ void SwigDirector_LoggerCallback::on_log(char const *msg, int const level) {
       PyObject *error = PyErr_Occurred();
       if (error) {
         Swig::DirectorMethodException::raise("Error detected when calling 'LoggerCallback.on_log'");
+      }
+    }
+  }
+  SWIG_PYTHON_THREAD_END_BLOCK;
+}
+
+
+SwigDirector_IRQCallback::SwigDirector_IRQCallback(PyObject *self, avr_irq_t *irq): IRQCallback(irq), Swig::Director(self) {
+  SWIG_DIRECTOR_RGTR((IRQCallback *)this, this); 
+}
+
+
+
+
+SwigDirector_IRQCallback::~SwigDirector_IRQCallback() {
+}
+
+void SwigDirector_IRQCallback::on_notify(avr_irq_t *irq, uint32_t value) {
+  SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+  {
+    swig::SwigVar_PyObject obj0;
+    obj0 = SWIG_NewPointerObj(SWIG_as_voidptr(irq), SWIGTYPE_p_avr_irq_t,  0 );
+    swig::SwigVar_PyObject obj1;
+    obj1 = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(value));
+    if (!swig_get_self()) {
+      Swig::DirectorException::raise("'self' uninitialized, maybe you forgot to call IRQCallback.__init__.");
+    }
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+    const size_t swig_method_index = 0;
+    const char * const swig_method_name = "on_notify";
+    PyObject* method = swig_get_method(swig_method_index, swig_method_name);
+    swig::SwigVar_PyObject result = PyObject_CallFunction(method, (char *)"(OO)" ,(PyObject *)obj0,(PyObject *)obj1);
+#else
+    swig::SwigVar_PyObject result = PyObject_CallMethod(swig_get_self(), (char *)"on_notify", (char *)"(OO)" ,(PyObject *)obj0,(PyObject *)obj1);
+#endif
+    if (!result) {
+      PyObject *error = PyErr_Occurred();
+      if (error) {
+        Swig::DirectorMethodException::raise("Error detected when calling 'IRQCallback.on_notify'");
       }
     }
   }
@@ -4477,6 +4623,16424 @@ SWIGINTERN PyObject *LoggerCallback_swigregister(PyObject *SWIGUNUSEDPARM(self),
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_new_IRQCallback(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  PyObject *arg1 = (PyObject *) 0 ;
+  avr_irq_t *arg2 = (avr_irq_t *) 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  IRQCallback *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:new_IRQCallback",&obj0,&obj1)) SWIG_fail;
+  arg1 = obj0;
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_irq_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "new_IRQCallback" "', argument " "2"" of type '" "avr_irq_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_irq_t * >(argp2);
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if ( arg1 != Py_None ) {
+      /* subclassed */
+      result = (IRQCallback *)new SwigDirector_IRQCallback(arg1,arg2); 
+    } else {
+      result = (IRQCallback *)new IRQCallback(arg2); 
+    }
+    
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_IRQCallback, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IRQCallback(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  IRQCallback *arg1 = (IRQCallback *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IRQCallback",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_IRQCallback, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IRQCallback" "', argument " "1"" of type '" "IRQCallback *""'"); 
+  }
+  arg1 = reinterpret_cast< IRQCallback * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IRQCallback_on_notify(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  IRQCallback *arg1 = (IRQCallback *) 0 ;
+  avr_irq_t *arg2 = (avr_irq_t *) 0 ;
+  uint32_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  unsigned long val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IRQCallback_on_notify",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_IRQCallback, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IRQCallback_on_notify" "', argument " "1"" of type '" "IRQCallback *""'"); 
+  }
+  arg1 = reinterpret_cast< IRQCallback * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_irq_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IRQCallback_on_notify" "', argument " "2"" of type '" "avr_irq_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_irq_t * >(argp2);
+  ecode3 = SWIG_AsVal_unsigned_SS_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IRQCallback_on_notify" "', argument " "3"" of type '" "uint32_t""'");
+  } 
+  arg3 = static_cast< uint32_t >(val3);
+  {
+    if (!arg2) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  director = SWIG_DIRECTOR_CAST(arg1);
+  upcall = (director && (director->swig_get_self()==obj0));
+  try {
+    if (upcall) {
+      (arg1)->IRQCallback::on_notify(arg2,arg3);
+    } else {
+      (arg1)->on_notify(arg2,arg3);
+    }
+  } catch (Swig::DirectorException&) {
+    SWIG_fail;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IRQCallback_get_irq(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  IRQCallback *arg1 = (IRQCallback *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_irq_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IRQCallback_get_irq",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_IRQCallback, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IRQCallback_get_irq" "', argument " "1"" of type '" "IRQCallback *""'"); 
+  }
+  arg1 = reinterpret_cast< IRQCallback * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_irq_t *)(arg1)->get_irq();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_irq_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_disown_IRQCallback(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  IRQCallback *arg1 = (IRQCallback *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:disown_IRQCallback",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_IRQCallback, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "disown_IRQCallback" "', argument " "1"" of type '" "IRQCallback *""'"); 
+  }
+  arg1 = reinterpret_cast< IRQCallback * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      Swig::Director *director = SWIG_DIRECTOR_CAST(arg1);
+      if (director) director->swig_disown();
+    }
+    
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IRQCallback_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_IRQCallback, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_DEF(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char arg2 ;
+  char arg3 ;
+  char arg4 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  char val3 ;
+  int ecode3 = 0 ;
+  char val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:AVR_IOCTL_DEF",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_DEF" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "AVR_IOCTL_DEF" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  ecode3 = SWIG_AsVal_char(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "AVR_IOCTL_DEF" "', argument " "3"" of type '" "char""'");
+  } 
+  arg3 = static_cast< char >(val3);
+  ecode4 = SWIG_AsVal_char(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "AVR_IOCTL_DEF" "', argument " "4"" of type '" "char""'");
+  } 
+  arg4 = static_cast< char >(val4);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_DEF(arg1,arg2,arg3,arg4);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_ADC_GETIRQ_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_ADC_GETIRQ",SWIG_From_long(static_cast< long >(AVR_IOCTL_ADC_GETIRQ)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_EEPROM_GET_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_EEPROM_GET",SWIG_From_long(static_cast< long >(AVR_IOCTL_EEPROM_GET)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_EEPROM_SET_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_EEPROM_SET",SWIG_From_long(static_cast< long >(AVR_IOCTL_EEPROM_SET)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_EXTINT_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)":AVR_IOCTL_EXTINT_GETIRQ")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_EXTINT_GETIRQ();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_FLASH_SPM_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_FLASH_SPM",SWIG_From_long(static_cast< long >(AVR_IOCTL_FLASH_SPM)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_IOPORT_GETIRQ_REGBIT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_IOPORT_GETIRQ_REGBIT",SWIG_From_long(static_cast< long >(AVR_IOCTL_IOPORT_GETIRQ_REGBIT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_IOPORT_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_IOPORT_GETIRQ",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_IOPORT_GETIRQ" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_IOPORT_GETIRQ(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_IOPORT_GETSTATE(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_IOPORT_GETSTATE",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_IOPORT_GETSTATE" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_IOPORT_GETSTATE(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_IOPORT_SET_EXTERNAL(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_IOPORT_SET_EXTERNAL",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_IOPORT_SET_EXTERNAL" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_IOPORT_SET_EXTERNAL(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_SPI_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_SPI_GETIRQ",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_SPI_GETIRQ" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_SPI_GETIRQ(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_TIMER_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_TIMER_GETIRQ",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_TIMER_GETIRQ" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_TIMER_GETIRQ(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_TIMER_SET_TRACE(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_TIMER_SET_TRACE",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_TIMER_SET_TRACE" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_TIMER_SET_TRACE(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_TWI_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_TWI_GETIRQ",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_TWI_GETIRQ" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_TWI_GETIRQ(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_UART_GET_FLAGS(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_UART_GET_FLAGS",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_UART_GET_FLAGS" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_UART_GET_FLAGS(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_UART_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_UART_GETIRQ",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_UART_GETIRQ" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_UART_GETIRQ(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_UART_SET_FLAGS(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char arg1 ;
+  char val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:AVR_IOCTL_UART_SET_FLAGS",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_char(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "AVR_IOCTL_UART_SET_FLAGS" "', argument " "1"" of type '" "char""'");
+  } 
+  arg1 = static_cast< char >(val1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_UART_SET_FLAGS(arg1);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_AVR_IOCTL_USB_GETIRQ(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)":AVR_IOCTL_USB_GETIRQ")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (long)AVR_IOCTL_USB_GETIRQ();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_READ_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_READ",SWIG_From_long(static_cast< long >(AVR_IOCTL_USB_READ)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_RESET_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_RESET",SWIG_From_long(static_cast< long >(AVR_IOCTL_USB_RESET)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_SETUP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_SETUP",SWIG_From_long(static_cast< long >(AVR_IOCTL_USB_SETUP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_VBUS_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_VBUS",SWIG_From_long(static_cast< long >(AVR_IOCTL_USB_VBUS)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_WRITE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_WRITE",SWIG_From_long(static_cast< long >(AVR_IOCTL_USB_WRITE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_WATCHDOG_RESET_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_WATCHDOG_RESET",SWIG_From_long(static_cast< long >(AVR_IOCTL_WATCHDOG_RESET)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC0",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC1_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC1",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC1)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC2_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC2",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC2)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC3_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC3",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC3)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC4_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC4",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC4)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC5_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC5",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC5)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC6_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC6",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC6)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC7_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC7",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC7)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC8_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC8",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC8)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC9_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC9",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC9)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC10_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC10",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC10)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC11_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC11",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC11)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC12_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC12",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC12)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC13_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC13",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC13)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC14_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC14",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC14)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_ADC15_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_ADC15",SWIG_From_int(static_cast< int >(ADC_IRQ_ADC15)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_TEMP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_TEMP",SWIG_From_int(static_cast< int >(ADC_IRQ_TEMP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_IN_TRIGGER_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_IN_TRIGGER",SWIG_From_int(static_cast< int >(ADC_IRQ_IN_TRIGGER)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_OUT_TRIGGER_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_OUT_TRIGGER",SWIG_From_int(static_cast< int >(ADC_IRQ_OUT_TRIGGER)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_IRQ_COUNT",SWIG_From_int(static_cast< int >(ADC_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_NONE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_NONE",SWIG_From_int(static_cast< int >(ADC_MUX_NONE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_NOISE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_NOISE",SWIG_From_int(static_cast< int >(ADC_MUX_NOISE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_SINGLE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_SINGLE",SWIG_From_int(static_cast< int >(ADC_MUX_SINGLE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_DIFF_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_DIFF",SWIG_From_int(static_cast< int >(ADC_MUX_DIFF)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_TEMP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_TEMP",SWIG_From_int(static_cast< int >(ADC_MUX_TEMP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_REF_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_REF",SWIG_From_int(static_cast< int >(ADC_MUX_REF)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_MUX_VCC4_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_MUX_VCC4",SWIG_From_int(static_cast< int >(ADC_MUX_VCC4)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_kind_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_mux_t_kind_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_kind_set" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_adc_mux_t_kind_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->kind = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_kind_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_mux_t_kind_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_kind_get" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->kind);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_gain_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_mux_t_gain_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_gain_set" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_adc_mux_t_gain_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->gain = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_gain_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_mux_t_gain_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_gain_get" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->gain);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_diff_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_mux_t_diff_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_diff_set" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_adc_mux_t_diff_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->diff = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_diff_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_mux_t_diff_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_diff_get" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->diff);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_src_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_mux_t_src_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_src_set" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_adc_mux_t_src_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->src = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_mux_t_src_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_mux_t_src_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_mux_t_src_get" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->src);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_adc_mux_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_adc_mux_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_adc_mux_t *)new avr_adc_mux_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_adc_mux_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_adc_mux_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_mux_t *arg1 = (avr_adc_mux_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_adc_mux_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_mux_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_adc_mux_t" "', argument " "1"" of type '" "avr_adc_mux_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_mux_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_adc_mux_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_adc_mux_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *ADC_VREF_AREF_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_VREF_AREF",SWIG_From_int(static_cast< int >(ADC_VREF_AREF)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_VREF_VCC_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_VREF_VCC",SWIG_From_int(static_cast< int >(ADC_VREF_VCC)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_VREF_AVCC_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_VREF_AVCC",SWIG_From_int(static_cast< int >(ADC_VREF_AVCC)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_VREF_V110_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_VREF_V110",SWIG_From_int(static_cast< int >(ADC_VREF_V110)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *ADC_VREF_V256_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "ADC_VREF_V256",SWIG_From_int(static_cast< int >(ADC_VREF_V256)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_none_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_none",SWIG_From_int(static_cast< int >(avr_adts_none)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_free_running_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_free_running",SWIG_From_int(static_cast< int >(avr_adts_free_running)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_analog_comparator_0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_analog_comparator_0",SWIG_From_int(static_cast< int >(avr_adts_analog_comparator_0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_analog_comparator_1_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_analog_comparator_1",SWIG_From_int(static_cast< int >(avr_adts_analog_comparator_1)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_analog_comparator_2_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_analog_comparator_2",SWIG_From_int(static_cast< int >(avr_adts_analog_comparator_2)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_analog_comparator_3_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_analog_comparator_3",SWIG_From_int(static_cast< int >(avr_adts_analog_comparator_3)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_external_interrupt_0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_external_interrupt_0",SWIG_From_int(static_cast< int >(avr_adts_external_interrupt_0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_0_compare_match_a_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_0_compare_match_a",SWIG_From_int(static_cast< int >(avr_adts_timer_0_compare_match_a)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_0_compare_match_b_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_0_compare_match_b",SWIG_From_int(static_cast< int >(avr_adts_timer_0_compare_match_b)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_0_overflow_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_0_overflow",SWIG_From_int(static_cast< int >(avr_adts_timer_0_overflow)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_1_compare_match_b_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_1_compare_match_b",SWIG_From_int(static_cast< int >(avr_adts_timer_1_compare_match_b)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_1_overflow_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_1_overflow",SWIG_From_int(static_cast< int >(avr_adts_timer_1_overflow)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_timer_1_capture_event_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_timer_1_capture_event",SWIG_From_int(static_cast< int >(avr_adts_timer_1_capture_event)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_pin_change_interrupt_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_pin_change_interrupt",SWIG_From_int(static_cast< int >(avr_adts_pin_change_interrupt)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_psc_module_0_sync_signal_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_psc_module_0_sync_signal",SWIG_From_int(static_cast< int >(avr_adts_psc_module_0_sync_signal)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_psc_module_1_sync_signal_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_psc_module_1_sync_signal",SWIG_From_int(static_cast< int >(avr_adts_psc_module_1_sync_signal)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_adts_psc_module_2_sync_signal_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_adts_psc_module_2_sync_signal",SWIG_From_int(static_cast< int >(avr_adts_psc_module_2_sync_signal)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_io_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_io_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_admux_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_r_admux_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_admux_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_r_admux_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_r_admux_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_admux = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_admux_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_r_admux_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_admux_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_admux);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_mux_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_mux_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_mux_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_mux_set" "', argument " "2"" of type '" "avr_regbit_t [6]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)6; ++ii) *(avr_regbit_t *)&arg1->mux[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""mux""' of type '""avr_regbit_t [6]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_mux_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_mux_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_mux_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->mux);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ref_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_ref_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ref_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_ref_set" "', argument " "2"" of type '" "avr_regbit_t [3]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)3; ++ii) *(avr_regbit_t *)&arg1->ref[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""ref""' of type '""avr_regbit_t [3]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ref_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_ref_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ref_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->ref);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ref_values_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint16_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_ref_values_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ref_values_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint16_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_ref_values_set" "', argument " "2"" of type '" "uint16_t [7]""'"); 
+  } 
+  arg2 = reinterpret_cast< uint16_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)7; ++ii) *(uint16_t *)&arg1->ref_values[ii] = *((uint16_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""ref_values""' of type '""uint16_t [7]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ref_values_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_ref_values_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ref_values_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint16_t *)(uint16_t *) ((arg1)->ref_values);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint16_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adlar_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adlar_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adlar_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adlar_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_adlar_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->adlar = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adlar_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adlar_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adlar_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->adlar);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcsra_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_r_adcsra_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcsra_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_r_adcsra_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_r_adcsra_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_adcsra = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcsra_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_r_adcsra_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcsra_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_adcsra);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_aden_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_aden_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_aden_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_aden_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_aden_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->aden = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_aden_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_aden_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_aden_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->aden);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adsc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adsc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adsc_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adsc_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_adsc_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->adsc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adsc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adsc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adsc_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->adsc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adate_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adate_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adate_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adate_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_adate_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->adate = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adate_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adate_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adate_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->adate);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adps_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adps_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adps_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adps_set" "', argument " "2"" of type '" "avr_regbit_t [3]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)3; ++ii) *(avr_regbit_t *)&arg1->adps[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""adps""' of type '""avr_regbit_t [3]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adps_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adps_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adps_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->adps);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcl_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_r_adcl_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcl_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_r_adcl_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_r_adcl_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_adcl = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcl_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_r_adcl_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcl_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_adcl);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adch_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_r_adch_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adch_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_r_adch_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_r_adch_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_adch = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adch_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_r_adch_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adch_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_adch);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcsrb_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_r_adcsrb_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcsrb_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_r_adcsrb_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_r_adcsrb_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_adcsrb = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_r_adcsrb_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_r_adcsrb_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_r_adcsrb_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_adcsrb);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adts_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adts_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->adts[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""adts""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adts_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->adts);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_op_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_adts_type *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adts_op_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_op_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_adts_type, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adts_op_set" "', argument " "2"" of type '" "avr_adts_type [16]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_adts_type * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)16; ++ii) *(avr_adts_type *)&arg1->adts_op[ii] = *((avr_adts_type *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""adts_op""' of type '""avr_adts_type [16]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_op_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_adts_type *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adts_op_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_op_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_adts_type *)(avr_adts_type *) ((arg1)->adts_op);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_adts_type, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_mode_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adts_mode_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_mode_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adts_mode_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_adts_mode_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->adts_mode = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adts_mode_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adts_mode_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adts_mode_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->adts_mode);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_bin_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_bin_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_bin_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_bin_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_bin_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->bin = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_bin_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_bin_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_bin_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->bin);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ipr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_ipr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ipr_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_ipr_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_ipr_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ipr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_ipr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_ipr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_ipr_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->ipr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adc_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adc_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_adc_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->adc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adc_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->adc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_muxmode_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  avr_adc_mux_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_muxmode_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_muxmode_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_muxmode_set" "', argument " "2"" of type '" "avr_adc_mux_t [64]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_adc_mux_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)64; ++ii) *(avr_adc_mux_t *)&arg1->muxmode[ii] = *((avr_adc_mux_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""muxmode""' of type '""avr_adc_mux_t [64]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_muxmode_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_adc_mux_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_muxmode_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_muxmode_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_adc_mux_t *)(avr_adc_mux_t *) ((arg1)->muxmode);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_adc_mux_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adc_values_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint16_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_adc_values_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adc_values_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint16_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_adc_values_set" "', argument " "2"" of type '" "uint16_t [8]""'"); 
+  } 
+  arg2 = reinterpret_cast< uint16_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)8; ++ii) *(uint16_t *)&arg1->adc_values[ii] = *((uint16_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""adc_values""' of type '""uint16_t [8]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_adc_values_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_adc_values_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_adc_values_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint16_t *)(uint16_t *) ((arg1)->adc_values);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint16_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_temp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_temp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_temp_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_temp_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_temp_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->temp = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_temp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_temp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_temp_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->temp);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_first_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_first_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_first_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_first_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_first_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->first = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_first_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_first_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_first_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->first);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_read_status_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_t_read_status_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_read_status_set" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_t_read_status_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_adc_t_read_status_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->read_status = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_adc_t_read_status_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_adc_t_read_status_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_t_read_status_get" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->read_status);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_adc_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_adc_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_adc_t *)new avr_adc_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_adc_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_adc_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_adc_t *arg1 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_adc_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_adc_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_adc_t" "', argument " "1"" of type '" "avr_adc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_adc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_adc_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_adc_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_adc_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_adc_t *arg2 = (avr_adc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_adc_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_adc_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_adc_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_adc_init" "', argument " "2"" of type '" "avr_adc_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_adc_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_adc_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_io_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_io_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eeprom_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_eeprom_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eeprom_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_eeprom_set" "', argument " "2"" of type '" "uint8_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->eeprom = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eeprom_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_eeprom_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eeprom_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *) ((arg1)->eeprom);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_size_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_size_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_size_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->size = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_size_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->size);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eearh_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_r_eearh_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eearh_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_r_eearh_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_r_eearh_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_eearh = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eearh_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_r_eearh_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eearh_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_eearh);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eearl_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_r_eearl_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eearl_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_r_eearl_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_r_eearl_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_eearl = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eearl_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_r_eearl_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eearl_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_eearl);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eedr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_r_eedr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eedr_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_r_eedr_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_r_eedr_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_eedr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eedr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_r_eedr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eedr_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_eedr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eecr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_r_eecr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eecr_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_r_eecr_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_r_eecr_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_eecr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_r_eecr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_r_eecr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_r_eecr_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_eecr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eepm_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_eepm_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eepm_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_eepm_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->eepm[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""eepm""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eepm_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_eepm_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eepm_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->eepm);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eempe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_eempe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eempe_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_eempe_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_eempe_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->eempe = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eempe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_eempe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eempe_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->eempe);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eepe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_eepe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eepe_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_eepe_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_eepe_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->eepe = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eepe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_eepe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eepe_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->eepe);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eere_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_eere_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eere_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_eere_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_eere_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->eere = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_eere_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_eere_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_eere_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->eere);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_ready_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_t_ready_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_ready_set" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_t_ready_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_t_ready_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ready = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_t_ready_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_t_ready_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_t_ready_get" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->ready);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_eeprom_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_eeprom_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_eeprom_t *)new avr_eeprom_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_eeprom_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_eeprom_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_t *arg1 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_eeprom_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_eeprom_t" "', argument " "1"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_eeprom_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_eeprom_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_eeprom_t *arg2 = (avr_eeprom_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_eeprom_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_init" "', argument " "2"" of type '" "avr_eeprom_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_eeprom_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_eeprom_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_ee_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_desc_t_ee_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_ee_set" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_desc_t_ee_set" "', argument " "2"" of type '" "uint8_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ee = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_ee_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_desc_t_ee_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_ee_get" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *) ((arg1)->ee);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_offset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_desc_t_offset_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_offset_set" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_eeprom_desc_t_offset_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_eeprom_desc_t_offset_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->offset = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_offset_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_desc_t_offset_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_offset_get" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->offset);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_eeprom_desc_t_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_size_set" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_eeprom_desc_t_size_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->size = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_eeprom_desc_t_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_eeprom_desc_t_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_eeprom_desc_t_size_get" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->size);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_eeprom_desc_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_eeprom_desc_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_eeprom_desc_t *)new avr_eeprom_desc_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_eeprom_desc_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_eeprom_desc_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_eeprom_desc_t *arg1 = (avr_eeprom_desc_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_eeprom_desc_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_eeprom_desc_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_eeprom_desc_t" "', argument " "1"" of type '" "avr_eeprom_desc_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_eeprom_desc_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_eeprom_desc_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_eeprom_desc_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT0",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT1_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT1",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT1)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT2_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT2",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT2)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT3_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT3",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT3)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT4_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT4",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT4)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT5_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT5",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT5)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT6_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT6",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT6)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_IRQ_OUT_INT7_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_IRQ_OUT_INT7",SWIG_From_int(static_cast< int >(EXTINT_IRQ_OUT_INT7)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *EXTINT_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "EXTINT_COUNT",SWIG_From_int(static_cast< int >(EXTINT_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_extint_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_extint_t *arg1 = (avr_extint_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_extint_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_extint_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_extint_t_io_set" "', argument " "1"" of type '" "avr_extint_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_extint_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_extint_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_extint_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_extint_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_extint_t *arg1 = (avr_extint_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_extint_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_extint_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_extint_t_io_get" "', argument " "1"" of type '" "avr_extint_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_extint_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_extint_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_extint_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_extint_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_extint_t *)new avr_extint_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_extint_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_extint_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_extint_t *arg1 = (avr_extint_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_extint_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_extint_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_extint_t" "', argument " "1"" of type '" "avr_extint_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_extint_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_extint_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_extint_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_extint_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_extint_t *arg2 = (avr_extint_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_extint_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_extint_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_extint_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_extint_init" "', argument " "2"" of type '" "avr_extint_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_extint_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_extint_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_io_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_io_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_flags_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_flags_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_flags_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_flags_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_flags_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->flags = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_flags_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_flags_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_flags_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->flags);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_tmppage_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  uint16_t *arg2 = (uint16_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_tmppage_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_tmppage_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint16_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_tmppage_set" "', argument " "2"" of type '" "uint16_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint16_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->tmppage = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_tmppage_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_tmppage_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_tmppage_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint16_t *) ((arg1)->tmppage);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint16_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_tmppage_used_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_tmppage_used_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_tmppage_used_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_tmppage_used_set" "', argument " "2"" of type '" "uint8_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->tmppage_used = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_tmppage_used_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_tmppage_used_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_tmppage_used_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *) ((arg1)->tmppage_used);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_spm_pagesize_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_spm_pagesize_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_spm_pagesize_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_spm_pagesize_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_spm_pagesize_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->spm_pagesize = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_spm_pagesize_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_spm_pagesize_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_spm_pagesize_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->spm_pagesize);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_r_spm_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_r_spm_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_r_spm_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_r_spm_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_r_spm_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_spm = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_r_spm_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_r_spm_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_r_spm_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_spm);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_selfprgen_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_selfprgen_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_selfprgen_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_selfprgen_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_selfprgen_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->selfprgen = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_selfprgen_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_selfprgen_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_selfprgen_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->selfprgen);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_pgers_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_pgers_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_pgers_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_pgers_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_pgers_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pgers = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_pgers_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_pgers_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_pgers_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->pgers);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_pgwrt_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_pgwrt_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_pgwrt_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_pgwrt_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_pgwrt_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pgwrt = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_pgwrt_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_pgwrt_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_pgwrt_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->pgwrt);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_blbset_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_blbset_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_blbset_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_blbset_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_blbset_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->blbset = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_blbset_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_blbset_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_blbset_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->blbset);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_rwwsre_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_rwwsre_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_rwwsre_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_rwwsre_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_rwwsre_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->rwwsre = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_rwwsre_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_rwwsre_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_rwwsre_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->rwwsre);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_rwwsb_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_rwwsb_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_rwwsb_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_rwwsb_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_rwwsb_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->rwwsb = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_rwwsb_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_rwwsb_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_rwwsb_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->rwwsb);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_flash_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_t_flash_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_flash_set" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_t_flash_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_flash_t_flash_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->flash = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_t_flash_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_flash_t_flash_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_t_flash_get" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->flash);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_flash_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_flash_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_flash_t *)new avr_flash_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_flash_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_flash_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_flash_t *arg1 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_flash_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_flash_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_flash_t" "', argument " "1"" of type '" "avr_flash_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_flash_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_flash_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_flash_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *AVR_SELFPROG_HAVE_RWW_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_SELFPROG_HAVE_RWW",SWIG_From_int(static_cast< int >((1 << 0))));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_flash_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_flash_t *arg2 = (avr_flash_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_flash_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_flash_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_flash_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_flash_init" "', argument " "2"" of type '" "avr_flash_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_flash_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_flash_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN0",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN1_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN1",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN1)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN2_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN2",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN2)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN3_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN3",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN3)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN4_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN4",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN4)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN5_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN5",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN5)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN6_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN6",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN6)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN7_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN7",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN7)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_PIN_ALL_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_PIN_ALL",SWIG_From_int(static_cast< int >(IOPORT_IRQ_PIN_ALL)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_DIRECTION_ALL_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_DIRECTION_ALL",SWIG_From_int(static_cast< int >(IOPORT_IRQ_DIRECTION_ALL)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_REG_PORT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_REG_PORT",SWIG_From_int(static_cast< int >(IOPORT_IRQ_REG_PORT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_REG_PIN_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_REG_PIN",SWIG_From_int(static_cast< int >(IOPORT_IRQ_REG_PIN)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *IOPORT_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "IOPORT_IRQ_COUNT",SWIG_From_int(static_cast< int >(IOPORT_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOPORT_OUTPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOPORT_OUTPUT",SWIG_From_int(static_cast< int >(0x100)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_getirq_t_bit_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *arg1 = (avr_ioport_getirq_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_getirq_t_bit_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_getirq_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_getirq_t_bit_set" "', argument " "1"" of type '" "avr_ioport_getirq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_getirq_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_getirq_t_bit_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_getirq_t_bit_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->bit = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_getirq_t_bit_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *arg1 = (avr_ioport_getirq_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_getirq_t_bit_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_getirq_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_getirq_t_bit_get" "', argument " "1"" of type '" "avr_ioport_getirq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_getirq_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->bit);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_getirq_t_irq_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *arg1 = (avr_ioport_getirq_t *) 0 ;
+  avr_irq_t **arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_getirq_t_irq_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_getirq_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_getirq_t_irq_set" "', argument " "1"" of type '" "avr_ioport_getirq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_getirq_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_p_avr_irq_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_getirq_t_irq_set" "', argument " "2"" of type '" "avr_irq_t *[8]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_irq_t ** >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)8; ++ii) *(avr_irq_t * *)&arg1->irq[ii] = *((avr_irq_t * *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""irq""' of type '""avr_irq_t *[8]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_getirq_t_irq_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *arg1 = (avr_ioport_getirq_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_irq_t **result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_getirq_t_irq_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_getirq_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_getirq_t_irq_get" "', argument " "1"" of type '" "avr_ioport_getirq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_getirq_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_irq_t **)(avr_irq_t **) ((arg1)->irq);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_p_avr_irq_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_ioport_getirq_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_ioport_getirq_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_ioport_getirq_t *)new avr_ioport_getirq_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_ioport_getirq_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_ioport_getirq_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_getirq_t *arg1 = (avr_ioport_getirq_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_ioport_getirq_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_getirq_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_ioport_getirq_t" "', argument " "1"" of type '" "avr_ioport_getirq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_getirq_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_ioport_getirq_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_ioport_getirq_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_state_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_name_set" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_state_t_name_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_state_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_name_get" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_port_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_state_t_port_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_port_set" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_state_t_port_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->port = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_port_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_state_t_port_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_port_get" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->port);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_ddr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_state_t_ddr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_ddr_set" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_state_t_ddr_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ddr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_ddr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_state_t_ddr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_ddr_get" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->ddr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_pin_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_state_t_pin_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_pin_set" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_state_t_pin_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pin = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_state_t_pin_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_state_t_pin_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_state_t_pin_get" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->pin);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_ioport_state_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_ioport_state_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_ioport_state_t *)new avr_ioport_state_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_ioport_state_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_ioport_state_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_state_t *arg1 = (avr_ioport_state_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_ioport_state_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_state_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_ioport_state_t" "', argument " "1"" of type '" "avr_ioport_state_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_state_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_ioport_state_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_ioport_state_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_external_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_name_set" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_external_t_name_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_external_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_name_get" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_mask_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_external_t_mask_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_mask_set" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_external_t_mask_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->mask = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_mask_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_external_t_mask_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_mask_get" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->mask);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_value_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  unsigned long arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_external_t_value_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_value_set" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_external_t_value_set" "', argument " "2"" of type '" "unsigned long""'");
+  } 
+  arg2 = static_cast< unsigned long >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->value = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_external_t_value_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  unsigned long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_external_t_value_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_external_t_value_get" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (unsigned long) ((arg1)->value);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_ioport_external_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_ioport_external_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_ioport_external_t *)new avr_ioport_external_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_ioport_external_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_ioport_external_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_external_t *arg1 = (avr_ioport_external_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_ioport_external_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_external_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_ioport_external_t" "', argument " "1"" of type '" "avr_ioport_external_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_external_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_ioport_external_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_ioport_external_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_iopin_t_port_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *arg1 = (avr_iopin_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_iopin_t_port_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_iopin_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_iopin_t_port_set" "', argument " "1"" of type '" "avr_iopin_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_iopin_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_iopin_t_port_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_iopin_t_port_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->port = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_iopin_t_port_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *arg1 = (avr_iopin_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_iopin_t_port_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_iopin_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_iopin_t_port_get" "', argument " "1"" of type '" "avr_iopin_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_iopin_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->port);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_iopin_t_pin_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *arg1 = (avr_iopin_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_iopin_t_pin_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_iopin_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_iopin_t_pin_set" "', argument " "1"" of type '" "avr_iopin_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_iopin_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_iopin_t_pin_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_iopin_t_pin_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pin = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_iopin_t_pin_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *arg1 = (avr_iopin_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_iopin_t_pin_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_iopin_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_iopin_t_pin_get" "', argument " "1"" of type '" "avr_iopin_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_iopin_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->pin);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_iopin_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_iopin_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_iopin_t *)new avr_iopin_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_iopin_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_iopin_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_iopin_t *arg1 = (avr_iopin_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_iopin_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_iopin_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_iopin_t" "', argument " "1"" of type '" "avr_iopin_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_iopin_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_iopin_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_iopin_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_io_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_io_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_name_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_ioport_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_name_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_port_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_r_port_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_port_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_r_port_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_r_port_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_port = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_port_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_r_port_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_port_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_port);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_ddr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_r_ddr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_ddr_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_r_ddr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_r_ddr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ddr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_ddr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_r_ddr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_ddr_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ddr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_pin_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_r_pin_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_pin_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_r_pin_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_r_pin_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_pin = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_pin_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_r_pin_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_pin_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_pin);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_pcint_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_pcint_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_pcint_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_pcint_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_pcint_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pcint = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_pcint_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_pcint_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_pcint_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->pcint);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_pcint_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_t_r_pcint_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_pcint_set" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_t_r_pcint_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_ioport_t_r_pcint_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_pcint = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_ioport_t_r_pcint_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_ioport_t_r_pcint_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_t_r_pcint_get" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_pcint);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_ioport_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_ioport_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_ioport_t *)new avr_ioport_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_ioport_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_ioport_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_ioport_t *arg1 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_ioport_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_ioport_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_ioport_t" "', argument " "1"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_ioport_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_ioport_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_ioport_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_ioport_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_ioport_t *arg2 = (avr_ioport_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_ioport_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_ioport_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_ioport_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_ioport_init" "', argument " "2"" of type '" "avr_ioport_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_ioport_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_ioport_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *SPI_IRQ_INPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "SPI_IRQ_INPUT",SWIG_From_int(static_cast< int >(SPI_IRQ_INPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *SPI_IRQ_OUTPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "SPI_IRQ_OUTPUT",SWIG_From_int(static_cast< int >(SPI_IRQ_OUTPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *SPI_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "SPI_IRQ_COUNT",SWIG_From_int(static_cast< int >(SPI_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_io_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_io_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_name_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_spi_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_name_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_disabled_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_disabled_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_disabled_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->disabled = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_disabled_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_disabled_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_disabled_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->disabled);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spdr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_r_spdr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spdr_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_r_spdr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_r_spdr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_spdr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spdr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_r_spdr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spdr_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_spdr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spcr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_r_spcr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spcr_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_r_spcr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_r_spcr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_spcr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spcr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_r_spcr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spcr_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_spcr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spsr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_r_spsr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spsr_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_r_spsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_r_spsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_spsr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_r_spsr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_r_spsr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_r_spsr_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_spsr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_spe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spe_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_spe_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_spe_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->spe = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_spe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spe_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->spe);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_mstr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_mstr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_mstr_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_mstr_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_mstr_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->mstr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_mstr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_mstr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_mstr_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->mstr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_spr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spr_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_spr_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->spr[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""spr""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_spr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spr_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->spr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spi_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_spi_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spi_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_spi_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_spi_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->spi = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_spi_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_spi_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_spi_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->spi);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_input_data_register_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_t_input_data_register_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_input_data_register_set" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_t_input_data_register_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_spi_t_input_data_register_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->input_data_register = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_spi_t_input_data_register_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_spi_t_input_data_register_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_t_input_data_register_get" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->input_data_register);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_spi_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_spi_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_spi_t *)new avr_spi_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_spi_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_spi_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_spi_t *arg1 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_spi_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_spi_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_spi_t" "', argument " "1"" of type '" "avr_spi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_spi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_spi_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_spi_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_spi_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_spi_t *arg2 = (avr_spi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_spi_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_spi_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_spi_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_spi_init" "', argument " "2"" of type '" "avr_spi_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_spi_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_spi_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *AVR_TIMER_COMPA_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_TIMER_COMPA",SWIG_From_int(static_cast< int >(AVR_TIMER_COMPA)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_TIMER_COMPB_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_TIMER_COMPB",SWIG_From_int(static_cast< int >(AVR_TIMER_COMPB)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_TIMER_COMPC_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_TIMER_COMPC",SWIG_From_int(static_cast< int >(AVR_TIMER_COMPC)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_TIMER_COMP_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_TIMER_COMP_COUNT",SWIG_From_int(static_cast< int >(AVR_TIMER_COMP_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TIMER_IRQ_OUT_PWM0_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TIMER_IRQ_OUT_PWM0",SWIG_From_int(static_cast< int >(TIMER_IRQ_OUT_PWM0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TIMER_IRQ_OUT_PWM1_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TIMER_IRQ_OUT_PWM1",SWIG_From_int(static_cast< int >(TIMER_IRQ_OUT_PWM1)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TIMER_IRQ_OUT_COMP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TIMER_IRQ_OUT_COMP",SWIG_From_int(static_cast< int >(TIMER_IRQ_OUT_COMP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TIMER_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TIMER_IRQ_COUNT",SWIG_From_int(static_cast< int >(TIMER_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_none_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_none",SWIG_From_int(static_cast< int >(avr_timer_wgm_none)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_normal_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_normal",SWIG_From_int(static_cast< int >(avr_timer_wgm_normal)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_ctc_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_ctc",SWIG_From_int(static_cast< int >(avr_timer_wgm_ctc)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_pwm_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_pwm",SWIG_From_int(static_cast< int >(avr_timer_wgm_pwm)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_fast_pwm_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_fast_pwm",SWIG_From_int(static_cast< int >(avr_timer_wgm_fast_pwm)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_fc_pwm_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_fc_pwm",SWIG_From_int(static_cast< int >(avr_timer_wgm_fc_pwm)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_com_normal_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_com_normal",SWIG_From_int(static_cast< int >(avr_timer_com_normal)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_com_toggle_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_com_toggle",SWIG_From_int(static_cast< int >(avr_timer_com_toggle)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_com_clear_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_com_clear",SWIG_From_int(static_cast< int >(avr_timer_com_clear)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_com_set_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_com_set",SWIG_From_int(static_cast< int >(avr_timer_com_set)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_reg_constant_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_reg_constant",SWIG_From_int(static_cast< int >(avr_timer_wgm_reg_constant)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_reg_ocra_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_reg_ocra",SWIG_From_int(static_cast< int >(avr_timer_wgm_reg_ocra)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_reg_icr_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_wgm_reg_icr",SWIG_From_int(static_cast< int >(avr_timer_wgm_reg_icr)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_top_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_wgm_t_top_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_top_set" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_wgm_t_top_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->top = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_top_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_wgm_t_top_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_top_get" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->top);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_bottom_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_wgm_t_bottom_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_bottom_set" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_wgm_t_bottom_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->bottom = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_bottom_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_wgm_t_bottom_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_bottom_get" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->bottom);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_wgm_t_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_size_set" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_wgm_t_size_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->size = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_wgm_t_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_size_get" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->size);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_kind_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_wgm_t_kind_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_kind_set" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_wgm_t_kind_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->kind = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_wgm_t_kind_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_wgm_t_kind_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_wgm_t_kind_get" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->kind);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_timer_wgm_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_timer_wgm_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_wgm_t *)new avr_timer_wgm_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_wgm_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_timer_wgm_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_wgm_t *arg1 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_timer_wgm_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_wgm_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_timer_wgm_t" "', argument " "1"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_wgm_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_timer_wgm_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_timer_wgm_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_interrupt_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_interrupt_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_interrupt_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_interrupt_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_interrupt_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->interrupt = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_interrupt_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_interrupt_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_interrupt_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->interrupt);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_timer_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_timer_t *arg2 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_timer_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_timer_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_timer_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_timer_set" "', argument " "2"" of type '" "avr_timer_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_timer_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->timer = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_timer_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_timer_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_timer_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_timer_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_t *) ((arg1)->timer);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_r_ocr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_r_ocr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_r_ocr_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_r_ocr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_r_ocr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ocr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_r_ocr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_r_ocr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_r_ocr_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ocr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_r_ocrh_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_r_ocrh_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_r_ocrh_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_r_ocrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_r_ocrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ocrh = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_r_ocrh_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_r_ocrh_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_r_ocrh_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ocrh);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_com_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_com_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_com_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_com_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_com_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->com = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_com_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_com_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_com_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->com);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_com_pin_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_com_pin_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_com_pin_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_com_pin_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_com_pin_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->com_pin = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_com_pin_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_com_pin_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_com_pin_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->com_pin);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_comp_cycles_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  uint64_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_comp_t_comp_cycles_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_comp_cycles_set" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_comp_t_comp_cycles_set" "', argument " "2"" of type '" "uint64_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_comp_t_comp_cycles_set" "', argument " "2"" of type '" "uint64_t""'");
+    } else {
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->comp_cycles = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_comp_t_comp_cycles_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint64_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_comp_t_comp_cycles_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_comp_t_comp_cycles_get" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->comp_cycles);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_timer_comp_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_timer_comp_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_comp_t *)new avr_timer_comp_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_comp_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_timer_comp_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_comp_t *arg1 = (avr_timer_comp_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_timer_comp_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_comp_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_timer_comp_t" "', argument " "1"" of type '" "avr_timer_comp_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_comp_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_timer_comp_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_timer_comp_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *avr_timer_trace_ocr_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_trace_ocr",SWIG_From_int(static_cast< int >(avr_timer_trace_ocr)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_trace_tcnt_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_trace_tcnt",SWIG_From_int(static_cast< int >(avr_timer_trace_tcnt)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_trace_compa_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_trace_compa",SWIG_From_int(static_cast< int >(avr_timer_trace_compa)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_trace_compb_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_trace_compb",SWIG_From_int(static_cast< int >(avr_timer_trace_compb)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *avr_timer_trace_compc_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "avr_timer_trace_compc",SWIG_From_int(static_cast< int >(avr_timer_trace_compc)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_io_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_io_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_name_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_name_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_trace_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_trace_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_trace_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_t_trace_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->trace = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_trace_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_trace_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_trace_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->trace);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_disabled_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_disabled_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_disabled_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->disabled = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_disabled_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_disabled_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_disabled_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->disabled);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_tcnt_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_r_tcnt_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_tcnt_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_r_tcnt_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_r_tcnt_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_tcnt = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_tcnt_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_r_tcnt_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_tcnt_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_tcnt);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_icr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_r_icr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_icr_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_r_icr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_r_icr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_icr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_icr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_r_icr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_icr_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_icr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_tcnth_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_r_tcnth_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_tcnth_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_r_tcnth_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_r_tcnth_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_tcnth = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_tcnth_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_r_tcnth_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_tcnth_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_tcnth);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_icrh_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_r_icrh_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_icrh_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_r_icrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_r_icrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_icrh = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_r_icrh_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_r_icrh_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_r_icrh_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_icrh);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_wgm_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_wgm_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->wgm[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""wgm""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_wgm_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->wgm);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_timer_wgm_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_wgm_op_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_wgm_op_set" "', argument " "2"" of type '" "avr_timer_wgm_t [16]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_timer_wgm_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)16; ++ii) *(avr_timer_wgm_t *)&arg1->wgm_op[ii] = *((avr_timer_wgm_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""wgm_op""' of type '""avr_timer_wgm_t [16]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_timer_wgm_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_wgm_op_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_wgm_t *)(avr_timer_wgm_t *) ((arg1)->wgm_op);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_mode_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_timer_wgm_t *arg2 = (avr_timer_wgm_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_mode_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_mode_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_mode_set" "', argument " "2"" of type '" "avr_timer_wgm_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_timer_wgm_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->mode = *arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_mode_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_timer_wgm_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_mode_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_mode_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_wgm_t *)& ((arg1)->mode);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_wgm_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_mode_kind_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_wgm_op_mode_kind_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_mode_kind_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_t_wgm_op_mode_kind_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->wgm_op_mode_kind = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_mode_kind_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_wgm_op_mode_kind_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_mode_kind_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (int) ((arg1)->wgm_op_mode_kind);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_mode_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_wgm_op_mode_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_mode_size_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_t_wgm_op_mode_size_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->wgm_op_mode_size = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_wgm_op_mode_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_wgm_op_mode_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_wgm_op_mode_size_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->wgm_op_mode_size);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_as2_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_as2_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_as2_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_as2_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_as2_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->as2 = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_as2_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_as2_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_as2_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->as2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_cs_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_cs_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->cs[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""cs""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_cs_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->cs);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_div_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint8_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_cs_div_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_div_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_cs_div_set" "', argument " "2"" of type '" "uint8_t [16]""'"); 
+  } 
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)16; ++ii) *(uint8_t *)&arg1->cs_div[ii] = *((uint8_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""cs_div""' of type '""uint8_t [16]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_div_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_cs_div_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_div_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *)(uint8_t *) ((arg1)->cs_div);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_div_clock_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_cs_div_clock_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_div_clock_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_timer_t_cs_div_clock_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->cs_div_clock = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_cs_div_clock_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_cs_div_clock_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_cs_div_clock_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->cs_div_clock);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_icp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_icp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_icp_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_icp_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_icp_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->icp = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_icp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_icp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_icp_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->icp);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_ices_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_ices_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_ices_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_ices_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_ices_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ices = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_ices_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_ices_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_ices_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->ices);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_comp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_timer_comp_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_comp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_comp_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_comp_set" "', argument " "2"" of type '" "avr_timer_comp_t [AVR_TIMER_COMP_COUNT]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_timer_comp_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)AVR_TIMER_COMP_COUNT; ++ii) *(avr_timer_comp_t *)&arg1->comp[ii] = *((avr_timer_comp_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""comp""' of type '""avr_timer_comp_t [AVR_TIMER_COMP_COUNT]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_comp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_timer_comp_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_comp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_comp_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_comp_t *)(avr_timer_comp_t *) ((arg1)->comp);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_comp_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_overflow_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_overflow_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_overflow_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_overflow_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_overflow_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->overflow = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_overflow_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_overflow_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_overflow_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->overflow);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_icr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_icr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_icr_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_icr_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_icr_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->icr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_icr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_icr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_icr_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->icr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_cycles_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint64_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_tov_cycles_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_cycles_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_tov_cycles_set" "', argument " "2"" of type '" "uint64_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_tov_cycles_set" "', argument " "2"" of type '" "uint64_t""'");
+    } else {
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->tov_cycles = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_cycles_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint64_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_tov_cycles_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_cycles_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->tov_cycles);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_base_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint64_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_tov_base_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_base_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint64_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_tov_base_set" "', argument " "2"" of type '" "uint64_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_tov_base_set" "', argument " "2"" of type '" "uint64_t""'");
+    } else {
+      uint64_t * temp = reinterpret_cast< uint64_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->tov_base = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_base_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint64_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_tov_base_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_base_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->tov_base);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint64_t(static_cast< const uint64_t& >(result))), SWIGTYPE_p_uint64_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_top_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_t_tov_top_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_top_set" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_t_tov_top_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_timer_t_tov_top_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->tov_top = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_timer_t_tov_top_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_timer_t_tov_top_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_t_tov_top_get" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->tov_top);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_timer_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_timer_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_timer_t *)new avr_timer_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_timer_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_timer_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_timer_t *arg1 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_timer_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_timer_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_timer_t" "', argument " "1"" of type '" "avr_timer_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_timer_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_timer_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_timer_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_timer_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_timer_t *arg2 = (avr_timer_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_timer_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_timer_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_timer_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_timer_init" "', argument " "2"" of type '" "avr_timer_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_timer_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_timer_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *TWI_IRQ_INPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_IRQ_INPUT",SWIG_From_int(static_cast< int >(TWI_IRQ_INPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_IRQ_OUTPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_IRQ_OUTPUT",SWIG_From_int(static_cast< int >(TWI_IRQ_OUTPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_IRQ_STATUS_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_IRQ_STATUS",SWIG_From_int(static_cast< int >(TWI_IRQ_STATUS)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_IRQ_COUNT",SWIG_From_int(static_cast< int >(TWI_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_START_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_START",SWIG_From_int(static_cast< int >(TWI_COND_START)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_STOP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_STOP",SWIG_From_int(static_cast< int >(TWI_COND_STOP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_ADDR_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_ADDR",SWIG_From_int(static_cast< int >(TWI_COND_ADDR)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_ACK_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_ACK",SWIG_From_int(static_cast< int >(TWI_COND_ACK)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_WRITE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_WRITE",SWIG_From_int(static_cast< int >(TWI_COND_WRITE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_READ_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_READ",SWIG_From_int(static_cast< int >(TWI_COND_READ)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *TWI_COND_SLAVE_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "TWI_COND_SLAVE",SWIG_From_int(static_cast< int >(TWI_COND_SLAVE)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_unused_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_msg_t_unused_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_unused_set" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_twi_msg_t_unused_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->unused = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_unused_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_msg_t_unused_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_unused_get" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->unused);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_msg_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_msg_t_msg_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_msg_set" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_twi_msg_t_msg_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->msg = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_msg_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_msg_t_msg_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_msg_get" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->msg);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_addr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_msg_t_addr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_addr_set" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_twi_msg_t_addr_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->addr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_addr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_msg_t_addr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_addr_get" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->addr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_data_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_msg_t_data_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_data_set" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_twi_msg_t_data_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->data = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_msg_t_data_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_msg_t_data_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_msg_t_data_get" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->data);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_twi_msg_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_twi_msg_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_twi_msg_t *)new avr_twi_msg_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_twi_msg_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_twi_msg_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_t *arg1 = (avr_twi_msg_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_twi_msg_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_twi_msg_t" "', argument " "1"" of type '" "avr_twi_msg_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_twi_msg_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_twi_msg_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_new_avr_twi_msg_irq_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_irq_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_twi_msg_irq_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_twi_msg_irq_t *)new avr_twi_msg_irq_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_twi_msg_irq_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_twi_msg_irq_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_msg_irq_t *arg1 = (avr_twi_msg_irq_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_twi_msg_irq_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_msg_irq_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_twi_msg_irq_t" "', argument " "1"" of type '" "avr_twi_msg_irq_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_msg_irq_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_twi_msg_irq_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_twi_msg_irq_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_io_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_io_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_name_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_twi_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_name_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_disabled_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_disabled_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_disabled_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->disabled = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_disabled_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_disabled_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_disabled_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->disabled);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twbr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twbr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twbr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twbr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twbr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twbr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twbr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twbr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twbr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twbr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twcr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twcr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twcr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twcr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twcr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twcr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twcr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twcr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twcr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twcr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twsr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twsr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twsr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twsr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twsr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twsr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twsr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twsr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twar_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twar_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twar_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twar_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twar_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twar = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twar_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twar_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twar_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twar);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twamr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twamr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twamr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twamr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twamr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twamr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twamr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twamr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twamr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twamr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twdr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_r_twdr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twdr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_r_twdr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_r_twdr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_twdr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_r_twdr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_r_twdr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_r_twdr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_twdr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twen_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twen_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twen_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twen_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twen_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twen = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twen_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twen_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twen_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twen);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twea_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twea_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twea_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twea_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twea_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twea = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twea_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twea_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twea_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twea);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsta_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twsta_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsta_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twsta_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twsta_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twsta = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsta_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twsta_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsta_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twsta);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsto_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twsto_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsto_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twsto_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twsto_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twsto = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsto_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twsto_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsto_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twsto);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twwc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twwc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twwc_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twwc_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twwc_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twwc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twwc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twwc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twwc_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twwc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twsr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twsr_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twsr_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twsr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twsr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twsr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twsr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twsr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twps_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twps_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twps_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twps_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twps_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twps = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twps_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twps_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twps_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twps);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twi_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_twi_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twi_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_twi_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_twi_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->twi = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_twi_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_twi_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_twi_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->twi);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_state_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_state_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_state_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_state_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_state_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->state = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_state_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_state_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_state_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->state);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_peer_addr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_peer_addr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_peer_addr_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_peer_addr_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_peer_addr_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->peer_addr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_peer_addr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_peer_addr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_peer_addr_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->peer_addr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_next_twstate_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_t_next_twstate_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_next_twstate_set" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_t_next_twstate_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_t_next_twstate_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->next_twstate = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_t_next_twstate_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_twi_t_next_twstate_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_t_next_twstate_get" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->next_twstate);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_twi_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_twi_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_twi_t *)new avr_twi_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_twi_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_twi_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_twi_t *arg1 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_twi_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_twi_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_twi_t" "', argument " "1"" of type '" "avr_twi_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_twi_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_twi_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_twi_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_twi_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_twi_t *arg2 = (avr_twi_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_twi_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_twi_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_init" "', argument " "2"" of type '" "avr_twi_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_twi_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_twi_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_twi_irq_msg(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uint8_t arg1 ;
+  uint8_t arg2 ;
+  uint8_t arg3 ;
+  void *argp1 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:avr_twi_irq_msg",&obj0,&obj1,&obj2)) SWIG_fail;
+  {
+    res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_twi_irq_msg" "', argument " "1"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp1) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_irq_msg" "', argument " "1"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp1);
+      arg1 = *temp;
+      if (SWIG_IsNewObj(res1)) delete temp;
+    }
+  }
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_twi_irq_msg" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_irq_msg" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "avr_twi_irq_msg" "', argument " "3"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_twi_irq_msg" "', argument " "3"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = avr_twi_irq_msg(arg1,arg2,arg3);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *uart_fifo_overflow_f_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "uart_fifo_overflow_f",SWIG_From_int(static_cast< int >(uart_fifo_overflow_f)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *uart_fifo_fifo_size_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "uart_fifo_fifo_size",SWIG_From_int(static_cast< int >(uart_fifo_fifo_size)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_buffer_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  uint8_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:uart_fifo_t_buffer_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_buffer_set" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "uart_fifo_t_buffer_set" "', argument " "2"" of type '" "uint8_t [uart_fifo_fifo_size]""'"); 
+  } 
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)uart_fifo_fifo_size; ++ii) *(uint8_t *)&arg1->buffer[ii] = *((uint8_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""buffer""' of type '""uint8_t [uart_fifo_fifo_size]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_buffer_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:uart_fifo_t_buffer_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_buffer_get" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *)(uint8_t *) ((arg1)->buffer);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_read_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:uart_fifo_t_read_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_read_set" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "uart_fifo_t_read_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "uart_fifo_t_read_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->read = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_read_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:uart_fifo_t_read_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_read_get" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->read);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_write_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  uint16_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:uart_fifo_t_write_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_write_set" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint16_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "uart_fifo_t_write_set" "', argument " "2"" of type '" "uint16_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "uart_fifo_t_write_set" "', argument " "2"" of type '" "uint16_t""'");
+    } else {
+      uint16_t * temp = reinterpret_cast< uint16_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->write = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_write_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint16_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:uart_fifo_t_write_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_write_get" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->write);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint16_t(static_cast< const uint16_t& >(result))), SWIGTYPE_p_uint16_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_flags_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:uart_fifo_t_flags_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_flags_set" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "uart_fifo_t_flags_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "uart_fifo_t_flags_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->flags = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_uart_fifo_t_flags_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:uart_fifo_t_flags_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "uart_fifo_t_flags_get" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->flags);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_uart_fifo_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_uart_fifo_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uart_fifo_t *)new uart_fifo_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uart_fifo_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_uart_fifo_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  uart_fifo_t *arg1 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_uart_fifo_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_uart_fifo_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_uart_fifo_t" "', argument " "1"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg1 = reinterpret_cast< uart_fifo_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *uart_fifo_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_uart_fifo_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *UART_IRQ_INPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "UART_IRQ_INPUT",SWIG_From_int(static_cast< int >(UART_IRQ_INPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *UART_IRQ_OUTPUT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "UART_IRQ_OUTPUT",SWIG_From_int(static_cast< int >(UART_IRQ_OUTPUT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *UART_IRQ_OUT_XON_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "UART_IRQ_OUT_XON",SWIG_From_int(static_cast< int >(UART_IRQ_OUT_XON)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *UART_IRQ_OUT_XOFF_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "UART_IRQ_OUT_XOFF",SWIG_From_int(static_cast< int >(UART_IRQ_OUT_XOFF)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *UART_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "UART_IRQ_COUNT",SWIG_From_int(static_cast< int >(UART_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_UART_FLAG_POOL_SLEEP_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_UART_FLAG_POOL_SLEEP",SWIG_From_int(static_cast< int >(AVR_UART_FLAG_POOL_SLEEP)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_UART_FLAG_STDIO_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_UART_FLAG_STDIO",SWIG_From_int(static_cast< int >(AVR_UART_FLAG_STDIO)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_io_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_io_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_name_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_uart_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_name_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_disabled_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_disabled_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_disabled_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->disabled = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_disabled_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_disabled_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_disabled_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->disabled);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_udr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_udr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_udr_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_udr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_udr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_udr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_udr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_udr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_udr_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_udr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsra_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_ucsra_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsra_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_ucsra_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_ucsra_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ucsra = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsra_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_ucsra_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsra_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ucsra);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsrb_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_ucsrb_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsrb_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_ucsrb_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_ucsrb_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ucsrb = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsrb_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_ucsrb_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsrb_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ucsrb);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsrc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_ucsrc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsrc_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_ucsrc_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_ucsrc_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ucsrc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ucsrc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_ucsrc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ucsrc_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ucsrc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_rxen_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_rxen_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_rxen_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_rxen_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_rxen_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->rxen = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_rxen_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_rxen_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_rxen_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->rxen);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_txen_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_txen_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_txen_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_txen_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_txen_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->txen = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_txen_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_txen_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_txen_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->txen);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_u2x_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_u2x_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_u2x_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_u2x_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_u2x_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->u2x = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_u2x_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_u2x_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_u2x_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->u2x);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_usbs_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_usbs_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_usbs_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_usbs_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_usbs_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->usbs = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_usbs_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_usbs_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_usbs_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->usbs);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_ucsz_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_ucsz_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_ucsz_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_ucsz_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_ucsz_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ucsz = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_ucsz_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_ucsz_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_ucsz_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->ucsz);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_ucsz2_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_ucsz2_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_ucsz2_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_ucsz2_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_ucsz2_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->ucsz2 = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_ucsz2_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_ucsz2_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_ucsz2_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->ucsz2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ubrrl_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_ubrrl_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ubrrl_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_ubrrl_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_ubrrl_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ubrrl = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ubrrl_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_ubrrl_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ubrrl_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ubrrl);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ubrrh_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_r_ubrrh_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ubrrh_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_r_ubrrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_r_ubrrh_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_ubrrh = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_r_ubrrh_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_r_ubrrh_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_r_ubrrh_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_ubrrh);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_rxc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_rxc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_rxc_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_rxc_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_rxc_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->rxc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_rxc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_rxc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_rxc_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->rxc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_txc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_txc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_txc_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_txc_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_txc_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->txc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_txc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_txc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_txc_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->txc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_udrc_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_udrc_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_udrc_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_udrc_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_uart_t_udrc_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->udrc = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_udrc_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_udrc_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_udrc_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->udrc);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_input_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  uart_fifo_t *arg2 = (uart_fifo_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_input_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_input_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_input_set" "', argument " "2"" of type '" "uart_fifo_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uart_fifo_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->input = *arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_input_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uart_fifo_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_input_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_input_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uart_fifo_t *)& ((arg1)->input);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uart_fifo_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_flags_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_flags_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_flags_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_uart_t_flags_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->flags = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_flags_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_flags_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_flags_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->flags);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_usec_per_byte_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  avr_cycle_count_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_usec_per_byte_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_usec_per_byte_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_uart_t_usec_per_byte_set" "', argument " "2"" of type '" "avr_cycle_count_t""'");
+  } 
+  arg2 = static_cast< avr_cycle_count_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->usec_per_byte = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_usec_per_byte_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_cycle_count_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_usec_per_byte_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_usec_per_byte_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->usec_per_byte);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long_SS_long(static_cast< unsigned long long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_stdio_out_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_stdio_out_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_stdio_out_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_t_stdio_out_set" "', argument " "2"" of type '" "uint8_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->stdio_out = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_stdio_out_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_stdio_out_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_stdio_out_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *) ((arg1)->stdio_out);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_stdio_len_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_t_stdio_len_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_stdio_len_set" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_uart_t_stdio_len_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->stdio_len = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_uart_t_stdio_len_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_uart_t_stdio_len_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_t_stdio_len_get" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (int) ((arg1)->stdio_len);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_uart_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_uart_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_uart_t *)new avr_uart_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_uart_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_uart_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_uart_t *arg1 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_uart_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_uart_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_uart_t" "', argument " "1"" of type '" "avr_uart_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_uart_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_uart_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_uart_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_uart_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_uart_t *arg2 = (avr_uart_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_uart_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_uart_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_uart_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_uart_init" "', argument " "2"" of type '" "avr_uart_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_uart_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_uart_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *USB_IRQ_ATTACH_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "USB_IRQ_ATTACH",SWIG_From_int(static_cast< int >(USB_IRQ_ATTACH)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *USB_IRQ_COUNT_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "USB_IRQ_COUNT",SWIG_From_int(static_cast< int >(USB_IRQ_COUNT)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_pipe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_io_usb_pipe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_pipe_set" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_io_usb_pipe_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_io_usb_pipe_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->pipe = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_pipe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_io_usb_pipe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_pipe_get" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->pipe);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_sz_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  uint32_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_io_usb_sz_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_sz_set" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_io_usb_sz_set" "', argument " "2"" of type '" "uint32_t""'");
+  } 
+  arg2 = static_cast< uint32_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->sz = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_sz_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint32_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_io_usb_sz_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_sz_get" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->sz);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_buf_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_io_usb_buf_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_buf_set" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_uint8_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_io_usb_buf_set" "', argument " "2"" of type '" "uint8_t *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->buf = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_io_usb_buf_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_io_usb_buf_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_io_usb_buf_get" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (uint8_t *) ((arg1)->buf);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_uint8_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_io_usb(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_io_usb")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_io_usb *)new avr_io_usb();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_io_usb, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_io_usb(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_io_usb *arg1 = (avr_io_usb *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_io_usb",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_io_usb, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_io_usb" "', argument " "1"" of type '" "avr_io_usb *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_io_usb * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_io_usb_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_io_usb, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_NAK_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_NAK",SWIG_From_int(static_cast< int >(-2)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_STALL_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_STALL",SWIG_From_int(static_cast< int >(-3)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *AVR_IOCTL_USB_OK_swigconstant(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *module;
+  PyObject *d;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigconstant", &module)) return NULL;
+  d = PyModule_GetDict(module);
+  if (!d) return NULL;
+  SWIG_Python_SetConstant(d, "AVR_IOCTL_USB_OK",SWIG_From_int(static_cast< int >(0)));
+  return SWIG_Py_Void();
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_io_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_io_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_name_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_name_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_name_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_usb_t_name_set" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->name = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_name_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_name_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_name_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (char) ((arg1)->name);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_disabled_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_disabled_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_disabled_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_disabled_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->disabled = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_disabled_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_disabled_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_disabled_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->disabled);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usbrf_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_usbrf_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usbrf_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_usbrf_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_usbrf_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->usbrf = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usbrf_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_usbrf_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usbrf_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->usbrf);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_r_usbcon_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_r_usbcon_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_r_usbcon_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_r_usbcon_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_r_usbcon_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_usbcon = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_r_usbcon_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_r_usbcon_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_r_usbcon_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_usbcon);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_r_pllcsr_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  avr_io_addr_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_r_pllcsr_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_r_pllcsr_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_addr_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_r_pllcsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_r_pllcsr_set" "', argument " "2"" of type '" "avr_io_addr_t""'");
+    } else {
+      avr_io_addr_t * temp = reinterpret_cast< avr_io_addr_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->r_pllcsr = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_r_pllcsr_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_addr_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_r_pllcsr_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_r_pllcsr_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->r_pllcsr);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_addr_t(static_cast< const avr_io_addr_t& >(result))), SWIGTYPE_p_avr_io_addr_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usb_com_vect_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_usb_com_vect_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usb_com_vect_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_usb_com_vect_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_usb_com_vect_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->usb_com_vect = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usb_com_vect_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_usb_com_vect_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usb_com_vect_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->usb_com_vect);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usb_gen_vect_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  uint8_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_usb_gen_vect_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usb_gen_vect_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_uint8_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_usb_gen_vect_set" "', argument " "2"" of type '" "uint8_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_usb_t_usb_gen_vect_set" "', argument " "2"" of type '" "uint8_t""'");
+    } else {
+      uint8_t * temp = reinterpret_cast< uint8_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->usb_gen_vect = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_usb_gen_vect_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  uint8_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_usb_gen_vect_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_usb_gen_vect_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->usb_gen_vect);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new uint8_t(static_cast< const uint8_t& >(result))), SWIGTYPE_p_uint8_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_state_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  usb_internal_state *arg2 = (usb_internal_state *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_t_state_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_state_set" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_usb_internal_state, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_t_state_set" "', argument " "2"" of type '" "usb_internal_state *""'"); 
+  }
+  arg2 = reinterpret_cast< usb_internal_state * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->state = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_usb_t_state_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  usb_internal_state *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_usb_t_state_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_t_state_get" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (usb_internal_state *) ((arg1)->state);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_usb_internal_state, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_usb_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_usb_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_usb_t *)new avr_usb_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_usb_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_usb_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_usb_t *arg1 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_usb_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_usb_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_usb_t" "', argument " "1"" of type '" "avr_usb_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_usb_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_usb_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_usb_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_usb_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_usb_t *arg2 = (avr_usb_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_usb_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_usb_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_usb_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_usb_init" "', argument " "2"" of type '" "avr_usb_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_usb_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_usb_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_io_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_io_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_io_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_io_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_io_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_io_set" "', argument " "2"" of type '" "avr_io_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_watchdog_t_io_set" "', argument " "2"" of type '" "avr_io_t""'");
+    } else {
+      avr_io_t * temp = reinterpret_cast< avr_io_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->io = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_io_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_io_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_io_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_io_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->io);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_io_t(static_cast< const avr_io_t& >(result))), SWIGTYPE_p_avr_io_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdrf_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_wdrf_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdrf_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_wdrf_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_watchdog_t_wdrf_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->wdrf = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdrf_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_wdrf_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdrf_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->wdrf);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdce_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_wdce_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdce_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_wdce_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_watchdog_t_wdce_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->wdce = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdce_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_wdce_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdce_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->wdce);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wde_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_regbit_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_wde_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wde_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_regbit_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_wde_set" "', argument " "2"" of type '" "avr_regbit_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_watchdog_t_wde_set" "', argument " "2"" of type '" "avr_regbit_t""'");
+    } else {
+      avr_regbit_t * temp = reinterpret_cast< avr_regbit_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->wde = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wde_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_wde_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wde_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->wde);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_regbit_t(static_cast< const avr_regbit_t& >(result))), SWIGTYPE_p_avr_regbit_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_regbit_t *arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_wdp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdp_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_wdp_set" "', argument " "2"" of type '" "avr_regbit_t [4]""'"); 
+  } 
+  arg2 = reinterpret_cast< avr_regbit_t * >(argp2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    {
+      if (arg2) {
+        size_t ii = 0;
+        for (; ii < (size_t)4; ++ii) *(avr_regbit_t *)&arg1->wdp[ii] = *((avr_regbit_t *)arg2 + ii);
+      } else {
+        SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in variable '""wdp""' of type '""avr_regbit_t [4]""'");
+      }
+    }
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_wdp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_regbit_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_wdp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_wdp_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_regbit_t *)(avr_regbit_t *) ((arg1)->wdp);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_regbit_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_watchdog_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_int_vector_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_watchdog_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_watchdog_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_avr_int_vector_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_t_watchdog_set" "', argument " "2"" of type '" "avr_int_vector_t""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "avr_watchdog_t_watchdog_set" "', argument " "2"" of type '" "avr_int_vector_t""'");
+    } else {
+      avr_int_vector_t * temp = reinterpret_cast< avr_int_vector_t * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->watchdog = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_watchdog_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_int_vector_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_watchdog_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_watchdog_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->watchdog);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new avr_int_vector_t(static_cast< const avr_int_vector_t& >(result))), SWIGTYPE_p_avr_int_vector_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_cycle_count_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  avr_cycle_count_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  unsigned long long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_t_cycle_count_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_cycle_count_set" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  ecode2 = SWIG_AsVal_unsigned_SS_long_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "avr_watchdog_t_cycle_count_set" "', argument " "2"" of type '" "avr_cycle_count_t""'");
+  } 
+  arg2 = static_cast< avr_cycle_count_t >(val2);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    if (arg1) (arg1)->cycle_count = arg2;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_t_cycle_count_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  avr_cycle_count_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:avr_watchdog_t_cycle_count_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_t_cycle_count_get" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result =  ((arg1)->cycle_count);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_From_unsigned_SS_long_SS_long(static_cast< unsigned long long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_avr_watchdog_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_avr_watchdog_t")) SWIG_fail;
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (avr_watchdog_t *)new avr_watchdog_t();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_avr_watchdog_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_avr_watchdog_t(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_watchdog_t *arg1 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_avr_watchdog_t",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_watchdog_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_avr_watchdog_t" "', argument " "1"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_watchdog_t * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    delete arg1;
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *avr_watchdog_t_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_avr_watchdog_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_avr_watchdog_init(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  avr_t *arg1 = (avr_t *) 0 ;
+  avr_watchdog_t *arg2 = (avr_watchdog_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:avr_watchdog_init",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_avr_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "avr_watchdog_init" "', argument " "1"" of type '" "avr_t *""'"); 
+  }
+  arg1 = reinterpret_cast< avr_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_avr_watchdog_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "avr_watchdog_init" "', argument " "2"" of type '" "avr_watchdog_t *""'"); 
+  }
+  arg2 = reinterpret_cast< avr_watchdog_t * >(argp2);
+  {
+    if (!arg1) {
+      SWIG_exception(SWIG_ValueError,"Received a NULL pointer.");
+    }
+  }
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    avr_watchdog_init(arg1,arg2);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 static PyMethodDef SwigMethods[] = {
 	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
 	 { (char *)"new_TimerCallback", _wrap_new_TimerCallback, METH_VARARGS, NULL},
@@ -4493,34 +21057,798 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"LoggerCallback_on_log", _wrap_LoggerCallback_on_log, METH_VARARGS, NULL},
 	 { (char *)"disown_LoggerCallback", _wrap_disown_LoggerCallback, METH_VARARGS, NULL},
 	 { (char *)"LoggerCallback_swigregister", LoggerCallback_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_IRQCallback", _wrap_new_IRQCallback, METH_VARARGS, NULL},
+	 { (char *)"delete_IRQCallback", _wrap_delete_IRQCallback, METH_VARARGS, NULL},
+	 { (char *)"IRQCallback_on_notify", _wrap_IRQCallback_on_notify, METH_VARARGS, NULL},
+	 { (char *)"IRQCallback_get_irq", _wrap_IRQCallback_get_irq, METH_VARARGS, NULL},
+	 { (char *)"disown_IRQCallback", _wrap_disown_IRQCallback, METH_VARARGS, NULL},
+	 { (char *)"IRQCallback_swigregister", IRQCallback_swigregister, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_DEF", _wrap_AVR_IOCTL_DEF, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_ADC_GETIRQ_swigconstant", AVR_IOCTL_ADC_GETIRQ_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_EEPROM_GET_swigconstant", AVR_IOCTL_EEPROM_GET_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_EEPROM_SET_swigconstant", AVR_IOCTL_EEPROM_SET_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_EXTINT_GETIRQ", _wrap_AVR_IOCTL_EXTINT_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_FLASH_SPM_swigconstant", AVR_IOCTL_FLASH_SPM_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_IOPORT_GETIRQ_REGBIT_swigconstant", AVR_IOCTL_IOPORT_GETIRQ_REGBIT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_IOPORT_GETIRQ", _wrap_AVR_IOCTL_IOPORT_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_IOPORT_GETSTATE", _wrap_AVR_IOCTL_IOPORT_GETSTATE, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_IOPORT_SET_EXTERNAL", _wrap_AVR_IOCTL_IOPORT_SET_EXTERNAL, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_SPI_GETIRQ", _wrap_AVR_IOCTL_SPI_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_TIMER_GETIRQ", _wrap_AVR_IOCTL_TIMER_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_TIMER_SET_TRACE", _wrap_AVR_IOCTL_TIMER_SET_TRACE, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_TWI_GETIRQ", _wrap_AVR_IOCTL_TWI_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_UART_GET_FLAGS", _wrap_AVR_IOCTL_UART_GET_FLAGS, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_UART_GETIRQ", _wrap_AVR_IOCTL_UART_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_UART_SET_FLAGS", _wrap_AVR_IOCTL_UART_SET_FLAGS, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_GETIRQ", _wrap_AVR_IOCTL_USB_GETIRQ, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_READ_swigconstant", AVR_IOCTL_USB_READ_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_RESET_swigconstant", AVR_IOCTL_USB_RESET_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_SETUP_swigconstant", AVR_IOCTL_USB_SETUP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_VBUS_swigconstant", AVR_IOCTL_USB_VBUS_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_WRITE_swigconstant", AVR_IOCTL_USB_WRITE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_WATCHDOG_RESET_swigconstant", AVR_IOCTL_WATCHDOG_RESET_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC0_swigconstant", ADC_IRQ_ADC0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC1_swigconstant", ADC_IRQ_ADC1_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC2_swigconstant", ADC_IRQ_ADC2_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC3_swigconstant", ADC_IRQ_ADC3_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC4_swigconstant", ADC_IRQ_ADC4_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC5_swigconstant", ADC_IRQ_ADC5_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC6_swigconstant", ADC_IRQ_ADC6_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC7_swigconstant", ADC_IRQ_ADC7_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC8_swigconstant", ADC_IRQ_ADC8_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC9_swigconstant", ADC_IRQ_ADC9_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC10_swigconstant", ADC_IRQ_ADC10_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC11_swigconstant", ADC_IRQ_ADC11_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC12_swigconstant", ADC_IRQ_ADC12_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC13_swigconstant", ADC_IRQ_ADC13_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC14_swigconstant", ADC_IRQ_ADC14_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_ADC15_swigconstant", ADC_IRQ_ADC15_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_TEMP_swigconstant", ADC_IRQ_TEMP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_IN_TRIGGER_swigconstant", ADC_IRQ_IN_TRIGGER_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_OUT_TRIGGER_swigconstant", ADC_IRQ_OUT_TRIGGER_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_IRQ_COUNT_swigconstant", ADC_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_NONE_swigconstant", ADC_MUX_NONE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_NOISE_swigconstant", ADC_MUX_NOISE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_SINGLE_swigconstant", ADC_MUX_SINGLE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_DIFF_swigconstant", ADC_MUX_DIFF_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_TEMP_swigconstant", ADC_MUX_TEMP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_REF_swigconstant", ADC_MUX_REF_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_MUX_VCC4_swigconstant", ADC_MUX_VCC4_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_kind_set", _wrap_avr_adc_mux_t_kind_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_kind_get", _wrap_avr_adc_mux_t_kind_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_gain_set", _wrap_avr_adc_mux_t_gain_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_gain_get", _wrap_avr_adc_mux_t_gain_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_diff_set", _wrap_avr_adc_mux_t_diff_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_diff_get", _wrap_avr_adc_mux_t_diff_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_src_set", _wrap_avr_adc_mux_t_src_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_src_get", _wrap_avr_adc_mux_t_src_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_adc_mux_t", _wrap_new_avr_adc_mux_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_adc_mux_t", _wrap_delete_avr_adc_mux_t, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_mux_t_swigregister", avr_adc_mux_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"ADC_VREF_AREF_swigconstant", ADC_VREF_AREF_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_VREF_VCC_swigconstant", ADC_VREF_VCC_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_VREF_AVCC_swigconstant", ADC_VREF_AVCC_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_VREF_V110_swigconstant", ADC_VREF_V110_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"ADC_VREF_V256_swigconstant", ADC_VREF_V256_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_none_swigconstant", avr_adts_none_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_free_running_swigconstant", avr_adts_free_running_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_analog_comparator_0_swigconstant", avr_adts_analog_comparator_0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_analog_comparator_1_swigconstant", avr_adts_analog_comparator_1_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_analog_comparator_2_swigconstant", avr_adts_analog_comparator_2_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_analog_comparator_3_swigconstant", avr_adts_analog_comparator_3_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_external_interrupt_0_swigconstant", avr_adts_external_interrupt_0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_0_compare_match_a_swigconstant", avr_adts_timer_0_compare_match_a_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_0_compare_match_b_swigconstant", avr_adts_timer_0_compare_match_b_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_0_overflow_swigconstant", avr_adts_timer_0_overflow_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_1_compare_match_b_swigconstant", avr_adts_timer_1_compare_match_b_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_1_overflow_swigconstant", avr_adts_timer_1_overflow_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_timer_1_capture_event_swigconstant", avr_adts_timer_1_capture_event_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_pin_change_interrupt_swigconstant", avr_adts_pin_change_interrupt_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_psc_module_0_sync_signal_swigconstant", avr_adts_psc_module_0_sync_signal_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_psc_module_1_sync_signal_swigconstant", avr_adts_psc_module_1_sync_signal_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adts_psc_module_2_sync_signal_swigconstant", avr_adts_psc_module_2_sync_signal_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_io_set", _wrap_avr_adc_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_io_get", _wrap_avr_adc_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_admux_set", _wrap_avr_adc_t_r_admux_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_admux_get", _wrap_avr_adc_t_r_admux_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_mux_set", _wrap_avr_adc_t_mux_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_mux_get", _wrap_avr_adc_t_mux_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ref_set", _wrap_avr_adc_t_ref_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ref_get", _wrap_avr_adc_t_ref_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ref_values_set", _wrap_avr_adc_t_ref_values_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ref_values_get", _wrap_avr_adc_t_ref_values_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adlar_set", _wrap_avr_adc_t_adlar_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adlar_get", _wrap_avr_adc_t_adlar_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcsra_set", _wrap_avr_adc_t_r_adcsra_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcsra_get", _wrap_avr_adc_t_r_adcsra_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_aden_set", _wrap_avr_adc_t_aden_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_aden_get", _wrap_avr_adc_t_aden_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adsc_set", _wrap_avr_adc_t_adsc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adsc_get", _wrap_avr_adc_t_adsc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adate_set", _wrap_avr_adc_t_adate_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adate_get", _wrap_avr_adc_t_adate_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adps_set", _wrap_avr_adc_t_adps_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adps_get", _wrap_avr_adc_t_adps_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcl_set", _wrap_avr_adc_t_r_adcl_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcl_get", _wrap_avr_adc_t_r_adcl_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adch_set", _wrap_avr_adc_t_r_adch_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adch_get", _wrap_avr_adc_t_r_adch_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcsrb_set", _wrap_avr_adc_t_r_adcsrb_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_r_adcsrb_get", _wrap_avr_adc_t_r_adcsrb_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_set", _wrap_avr_adc_t_adts_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_get", _wrap_avr_adc_t_adts_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_op_set", _wrap_avr_adc_t_adts_op_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_op_get", _wrap_avr_adc_t_adts_op_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_mode_set", _wrap_avr_adc_t_adts_mode_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adts_mode_get", _wrap_avr_adc_t_adts_mode_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_bin_set", _wrap_avr_adc_t_bin_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_bin_get", _wrap_avr_adc_t_bin_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ipr_set", _wrap_avr_adc_t_ipr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_ipr_get", _wrap_avr_adc_t_ipr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adc_set", _wrap_avr_adc_t_adc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adc_get", _wrap_avr_adc_t_adc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_muxmode_set", _wrap_avr_adc_t_muxmode_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_muxmode_get", _wrap_avr_adc_t_muxmode_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adc_values_set", _wrap_avr_adc_t_adc_values_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_adc_values_get", _wrap_avr_adc_t_adc_values_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_temp_set", _wrap_avr_adc_t_temp_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_temp_get", _wrap_avr_adc_t_temp_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_first_set", _wrap_avr_adc_t_first_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_first_get", _wrap_avr_adc_t_first_get, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_read_status_set", _wrap_avr_adc_t_read_status_set, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_read_status_get", _wrap_avr_adc_t_read_status_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_adc_t", _wrap_new_avr_adc_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_adc_t", _wrap_delete_avr_adc_t, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_t_swigregister", avr_adc_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_adc_init", _wrap_avr_adc_init, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_io_set", _wrap_avr_eeprom_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_io_get", _wrap_avr_eeprom_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eeprom_set", _wrap_avr_eeprom_t_eeprom_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eeprom_get", _wrap_avr_eeprom_t_eeprom_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_size_set", _wrap_avr_eeprom_t_size_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_size_get", _wrap_avr_eeprom_t_size_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eearh_set", _wrap_avr_eeprom_t_r_eearh_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eearh_get", _wrap_avr_eeprom_t_r_eearh_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eearl_set", _wrap_avr_eeprom_t_r_eearl_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eearl_get", _wrap_avr_eeprom_t_r_eearl_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eedr_set", _wrap_avr_eeprom_t_r_eedr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eedr_get", _wrap_avr_eeprom_t_r_eedr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eecr_set", _wrap_avr_eeprom_t_r_eecr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_r_eecr_get", _wrap_avr_eeprom_t_r_eecr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eepm_set", _wrap_avr_eeprom_t_eepm_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eepm_get", _wrap_avr_eeprom_t_eepm_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eempe_set", _wrap_avr_eeprom_t_eempe_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eempe_get", _wrap_avr_eeprom_t_eempe_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eepe_set", _wrap_avr_eeprom_t_eepe_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eepe_get", _wrap_avr_eeprom_t_eepe_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eere_set", _wrap_avr_eeprom_t_eere_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_eere_get", _wrap_avr_eeprom_t_eere_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_ready_set", _wrap_avr_eeprom_t_ready_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_ready_get", _wrap_avr_eeprom_t_ready_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_eeprom_t", _wrap_new_avr_eeprom_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_eeprom_t", _wrap_delete_avr_eeprom_t, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_t_swigregister", avr_eeprom_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_init", _wrap_avr_eeprom_init, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_ee_set", _wrap_avr_eeprom_desc_t_ee_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_ee_get", _wrap_avr_eeprom_desc_t_ee_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_offset_set", _wrap_avr_eeprom_desc_t_offset_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_offset_get", _wrap_avr_eeprom_desc_t_offset_get, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_size_set", _wrap_avr_eeprom_desc_t_size_set, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_size_get", _wrap_avr_eeprom_desc_t_size_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_eeprom_desc_t", _wrap_new_avr_eeprom_desc_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_eeprom_desc_t", _wrap_delete_avr_eeprom_desc_t, METH_VARARGS, NULL},
+	 { (char *)"avr_eeprom_desc_t_swigregister", avr_eeprom_desc_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT0_swigconstant", EXTINT_IRQ_OUT_INT0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT1_swigconstant", EXTINT_IRQ_OUT_INT1_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT2_swigconstant", EXTINT_IRQ_OUT_INT2_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT3_swigconstant", EXTINT_IRQ_OUT_INT3_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT4_swigconstant", EXTINT_IRQ_OUT_INT4_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT5_swigconstant", EXTINT_IRQ_OUT_INT5_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT6_swigconstant", EXTINT_IRQ_OUT_INT6_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_IRQ_OUT_INT7_swigconstant", EXTINT_IRQ_OUT_INT7_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"EXTINT_COUNT_swigconstant", EXTINT_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_extint_t_io_set", _wrap_avr_extint_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_extint_t_io_get", _wrap_avr_extint_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_extint_t", _wrap_new_avr_extint_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_extint_t", _wrap_delete_avr_extint_t, METH_VARARGS, NULL},
+	 { (char *)"avr_extint_t_swigregister", avr_extint_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_extint_init", _wrap_avr_extint_init, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_io_set", _wrap_avr_flash_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_io_get", _wrap_avr_flash_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_flags_set", _wrap_avr_flash_t_flags_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_flags_get", _wrap_avr_flash_t_flags_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_tmppage_set", _wrap_avr_flash_t_tmppage_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_tmppage_get", _wrap_avr_flash_t_tmppage_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_tmppage_used_set", _wrap_avr_flash_t_tmppage_used_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_tmppage_used_get", _wrap_avr_flash_t_tmppage_used_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_spm_pagesize_set", _wrap_avr_flash_t_spm_pagesize_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_spm_pagesize_get", _wrap_avr_flash_t_spm_pagesize_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_r_spm_set", _wrap_avr_flash_t_r_spm_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_r_spm_get", _wrap_avr_flash_t_r_spm_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_selfprgen_set", _wrap_avr_flash_t_selfprgen_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_selfprgen_get", _wrap_avr_flash_t_selfprgen_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_pgers_set", _wrap_avr_flash_t_pgers_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_pgers_get", _wrap_avr_flash_t_pgers_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_pgwrt_set", _wrap_avr_flash_t_pgwrt_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_pgwrt_get", _wrap_avr_flash_t_pgwrt_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_blbset_set", _wrap_avr_flash_t_blbset_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_blbset_get", _wrap_avr_flash_t_blbset_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_rwwsre_set", _wrap_avr_flash_t_rwwsre_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_rwwsre_get", _wrap_avr_flash_t_rwwsre_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_rwwsb_set", _wrap_avr_flash_t_rwwsb_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_rwwsb_get", _wrap_avr_flash_t_rwwsb_get, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_flash_set", _wrap_avr_flash_t_flash_set, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_flash_get", _wrap_avr_flash_t_flash_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_flash_t", _wrap_new_avr_flash_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_flash_t", _wrap_delete_avr_flash_t, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_t_swigregister", avr_flash_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"AVR_SELFPROG_HAVE_RWW_swigconstant", AVR_SELFPROG_HAVE_RWW_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_flash_init", _wrap_avr_flash_init, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN0_swigconstant", IOPORT_IRQ_PIN0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN1_swigconstant", IOPORT_IRQ_PIN1_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN2_swigconstant", IOPORT_IRQ_PIN2_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN3_swigconstant", IOPORT_IRQ_PIN3_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN4_swigconstant", IOPORT_IRQ_PIN4_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN5_swigconstant", IOPORT_IRQ_PIN5_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN6_swigconstant", IOPORT_IRQ_PIN6_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN7_swigconstant", IOPORT_IRQ_PIN7_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_PIN_ALL_swigconstant", IOPORT_IRQ_PIN_ALL_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_DIRECTION_ALL_swigconstant", IOPORT_IRQ_DIRECTION_ALL_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_REG_PORT_swigconstant", IOPORT_IRQ_REG_PORT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_REG_PIN_swigconstant", IOPORT_IRQ_REG_PIN_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"IOPORT_IRQ_COUNT_swigconstant", IOPORT_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOPORT_OUTPUT_swigconstant", AVR_IOPORT_OUTPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_getirq_t_bit_set", _wrap_avr_ioport_getirq_t_bit_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_getirq_t_bit_get", _wrap_avr_ioport_getirq_t_bit_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_getirq_t_irq_set", _wrap_avr_ioport_getirq_t_irq_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_getirq_t_irq_get", _wrap_avr_ioport_getirq_t_irq_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_ioport_getirq_t", _wrap_new_avr_ioport_getirq_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_ioport_getirq_t", _wrap_delete_avr_ioport_getirq_t, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_getirq_t_swigregister", avr_ioport_getirq_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_name_set", _wrap_avr_ioport_state_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_name_get", _wrap_avr_ioport_state_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_port_set", _wrap_avr_ioport_state_t_port_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_port_get", _wrap_avr_ioport_state_t_port_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_ddr_set", _wrap_avr_ioport_state_t_ddr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_ddr_get", _wrap_avr_ioport_state_t_ddr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_pin_set", _wrap_avr_ioport_state_t_pin_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_pin_get", _wrap_avr_ioport_state_t_pin_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_ioport_state_t", _wrap_new_avr_ioport_state_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_ioport_state_t", _wrap_delete_avr_ioport_state_t, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_state_t_swigregister", avr_ioport_state_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_name_set", _wrap_avr_ioport_external_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_name_get", _wrap_avr_ioport_external_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_mask_set", _wrap_avr_ioport_external_t_mask_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_mask_get", _wrap_avr_ioport_external_t_mask_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_value_set", _wrap_avr_ioport_external_t_value_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_value_get", _wrap_avr_ioport_external_t_value_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_ioport_external_t", _wrap_new_avr_ioport_external_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_ioport_external_t", _wrap_delete_avr_ioport_external_t, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_external_t_swigregister", avr_ioport_external_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_iopin_t_port_set", _wrap_avr_iopin_t_port_set, METH_VARARGS, NULL},
+	 { (char *)"avr_iopin_t_port_get", _wrap_avr_iopin_t_port_get, METH_VARARGS, NULL},
+	 { (char *)"avr_iopin_t_pin_set", _wrap_avr_iopin_t_pin_set, METH_VARARGS, NULL},
+	 { (char *)"avr_iopin_t_pin_get", _wrap_avr_iopin_t_pin_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_iopin_t", _wrap_new_avr_iopin_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_iopin_t", _wrap_delete_avr_iopin_t, METH_VARARGS, NULL},
+	 { (char *)"avr_iopin_t_swigregister", avr_iopin_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_io_set", _wrap_avr_ioport_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_io_get", _wrap_avr_ioport_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_name_set", _wrap_avr_ioport_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_name_get", _wrap_avr_ioport_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_port_set", _wrap_avr_ioport_t_r_port_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_port_get", _wrap_avr_ioport_t_r_port_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_ddr_set", _wrap_avr_ioport_t_r_ddr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_ddr_get", _wrap_avr_ioport_t_r_ddr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_pin_set", _wrap_avr_ioport_t_r_pin_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_pin_get", _wrap_avr_ioport_t_r_pin_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_pcint_set", _wrap_avr_ioport_t_pcint_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_pcint_get", _wrap_avr_ioport_t_pcint_get, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_pcint_set", _wrap_avr_ioport_t_r_pcint_set, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_r_pcint_get", _wrap_avr_ioport_t_r_pcint_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_ioport_t", _wrap_new_avr_ioport_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_ioport_t", _wrap_delete_avr_ioport_t, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_t_swigregister", avr_ioport_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_ioport_init", _wrap_avr_ioport_init, METH_VARARGS, NULL},
+	 { (char *)"SPI_IRQ_INPUT_swigconstant", SPI_IRQ_INPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"SPI_IRQ_OUTPUT_swigconstant", SPI_IRQ_OUTPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"SPI_IRQ_COUNT_swigconstant", SPI_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_io_set", _wrap_avr_spi_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_io_get", _wrap_avr_spi_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_name_set", _wrap_avr_spi_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_name_get", _wrap_avr_spi_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_disabled_set", _wrap_avr_spi_t_disabled_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_disabled_get", _wrap_avr_spi_t_disabled_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spdr_set", _wrap_avr_spi_t_r_spdr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spdr_get", _wrap_avr_spi_t_r_spdr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spcr_set", _wrap_avr_spi_t_r_spcr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spcr_get", _wrap_avr_spi_t_r_spcr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spsr_set", _wrap_avr_spi_t_r_spsr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_r_spsr_get", _wrap_avr_spi_t_r_spsr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spe_set", _wrap_avr_spi_t_spe_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spe_get", _wrap_avr_spi_t_spe_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_mstr_set", _wrap_avr_spi_t_mstr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_mstr_get", _wrap_avr_spi_t_mstr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spr_set", _wrap_avr_spi_t_spr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spr_get", _wrap_avr_spi_t_spr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spi_set", _wrap_avr_spi_t_spi_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_spi_get", _wrap_avr_spi_t_spi_get, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_input_data_register_set", _wrap_avr_spi_t_input_data_register_set, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_input_data_register_get", _wrap_avr_spi_t_input_data_register_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_spi_t", _wrap_new_avr_spi_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_spi_t", _wrap_delete_avr_spi_t, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_t_swigregister", avr_spi_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_spi_init", _wrap_avr_spi_init, METH_VARARGS, NULL},
+	 { (char *)"AVR_TIMER_COMPA_swigconstant", AVR_TIMER_COMPA_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_TIMER_COMPB_swigconstant", AVR_TIMER_COMPB_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_TIMER_COMPC_swigconstant", AVR_TIMER_COMPC_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_TIMER_COMP_COUNT_swigconstant", AVR_TIMER_COMP_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TIMER_IRQ_OUT_PWM0_swigconstant", TIMER_IRQ_OUT_PWM0_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TIMER_IRQ_OUT_PWM1_swigconstant", TIMER_IRQ_OUT_PWM1_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TIMER_IRQ_OUT_COMP_swigconstant", TIMER_IRQ_OUT_COMP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TIMER_IRQ_COUNT_swigconstant", TIMER_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_none_swigconstant", avr_timer_wgm_none_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_normal_swigconstant", avr_timer_wgm_normal_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_ctc_swigconstant", avr_timer_wgm_ctc_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_pwm_swigconstant", avr_timer_wgm_pwm_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_fast_pwm_swigconstant", avr_timer_wgm_fast_pwm_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_fc_pwm_swigconstant", avr_timer_wgm_fc_pwm_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_com_normal_swigconstant", avr_timer_com_normal_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_com_toggle_swigconstant", avr_timer_com_toggle_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_com_clear_swigconstant", avr_timer_com_clear_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_com_set_swigconstant", avr_timer_com_set_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_reg_constant_swigconstant", avr_timer_wgm_reg_constant_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_reg_ocra_swigconstant", avr_timer_wgm_reg_ocra_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_reg_icr_swigconstant", avr_timer_wgm_reg_icr_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_top_set", _wrap_avr_timer_wgm_t_top_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_top_get", _wrap_avr_timer_wgm_t_top_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_bottom_set", _wrap_avr_timer_wgm_t_bottom_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_bottom_get", _wrap_avr_timer_wgm_t_bottom_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_size_set", _wrap_avr_timer_wgm_t_size_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_size_get", _wrap_avr_timer_wgm_t_size_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_kind_set", _wrap_avr_timer_wgm_t_kind_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_kind_get", _wrap_avr_timer_wgm_t_kind_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_timer_wgm_t", _wrap_new_avr_timer_wgm_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_timer_wgm_t", _wrap_delete_avr_timer_wgm_t, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_wgm_t_swigregister", avr_timer_wgm_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_interrupt_set", _wrap_avr_timer_comp_t_interrupt_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_interrupt_get", _wrap_avr_timer_comp_t_interrupt_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_timer_set", _wrap_avr_timer_comp_t_timer_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_timer_get", _wrap_avr_timer_comp_t_timer_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_r_ocr_set", _wrap_avr_timer_comp_t_r_ocr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_r_ocr_get", _wrap_avr_timer_comp_t_r_ocr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_r_ocrh_set", _wrap_avr_timer_comp_t_r_ocrh_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_r_ocrh_get", _wrap_avr_timer_comp_t_r_ocrh_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_com_set", _wrap_avr_timer_comp_t_com_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_com_get", _wrap_avr_timer_comp_t_com_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_com_pin_set", _wrap_avr_timer_comp_t_com_pin_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_com_pin_get", _wrap_avr_timer_comp_t_com_pin_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_comp_cycles_set", _wrap_avr_timer_comp_t_comp_cycles_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_comp_cycles_get", _wrap_avr_timer_comp_t_comp_cycles_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_timer_comp_t", _wrap_new_avr_timer_comp_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_timer_comp_t", _wrap_delete_avr_timer_comp_t, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_comp_t_swigregister", avr_timer_comp_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_trace_ocr_swigconstant", avr_timer_trace_ocr_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_trace_tcnt_swigconstant", avr_timer_trace_tcnt_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_trace_compa_swigconstant", avr_timer_trace_compa_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_trace_compb_swigconstant", avr_timer_trace_compb_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_trace_compc_swigconstant", avr_timer_trace_compc_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_io_set", _wrap_avr_timer_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_io_get", _wrap_avr_timer_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_name_set", _wrap_avr_timer_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_name_get", _wrap_avr_timer_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_trace_set", _wrap_avr_timer_t_trace_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_trace_get", _wrap_avr_timer_t_trace_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_disabled_set", _wrap_avr_timer_t_disabled_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_disabled_get", _wrap_avr_timer_t_disabled_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_tcnt_set", _wrap_avr_timer_t_r_tcnt_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_tcnt_get", _wrap_avr_timer_t_r_tcnt_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_icr_set", _wrap_avr_timer_t_r_icr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_icr_get", _wrap_avr_timer_t_r_icr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_tcnth_set", _wrap_avr_timer_t_r_tcnth_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_tcnth_get", _wrap_avr_timer_t_r_tcnth_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_icrh_set", _wrap_avr_timer_t_r_icrh_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_r_icrh_get", _wrap_avr_timer_t_r_icrh_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_set", _wrap_avr_timer_t_wgm_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_get", _wrap_avr_timer_t_wgm_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_set", _wrap_avr_timer_t_wgm_op_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_get", _wrap_avr_timer_t_wgm_op_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_mode_set", _wrap_avr_timer_t_mode_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_mode_get", _wrap_avr_timer_t_mode_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_mode_kind_set", _wrap_avr_timer_t_wgm_op_mode_kind_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_mode_kind_get", _wrap_avr_timer_t_wgm_op_mode_kind_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_mode_size_set", _wrap_avr_timer_t_wgm_op_mode_size_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_wgm_op_mode_size_get", _wrap_avr_timer_t_wgm_op_mode_size_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_as2_set", _wrap_avr_timer_t_as2_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_as2_get", _wrap_avr_timer_t_as2_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_set", _wrap_avr_timer_t_cs_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_get", _wrap_avr_timer_t_cs_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_div_set", _wrap_avr_timer_t_cs_div_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_div_get", _wrap_avr_timer_t_cs_div_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_div_clock_set", _wrap_avr_timer_t_cs_div_clock_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_cs_div_clock_get", _wrap_avr_timer_t_cs_div_clock_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_icp_set", _wrap_avr_timer_t_icp_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_icp_get", _wrap_avr_timer_t_icp_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_ices_set", _wrap_avr_timer_t_ices_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_ices_get", _wrap_avr_timer_t_ices_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_comp_set", _wrap_avr_timer_t_comp_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_comp_get", _wrap_avr_timer_t_comp_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_overflow_set", _wrap_avr_timer_t_overflow_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_overflow_get", _wrap_avr_timer_t_overflow_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_icr_set", _wrap_avr_timer_t_icr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_icr_get", _wrap_avr_timer_t_icr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_cycles_set", _wrap_avr_timer_t_tov_cycles_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_cycles_get", _wrap_avr_timer_t_tov_cycles_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_base_set", _wrap_avr_timer_t_tov_base_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_base_get", _wrap_avr_timer_t_tov_base_get, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_top_set", _wrap_avr_timer_t_tov_top_set, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_tov_top_get", _wrap_avr_timer_t_tov_top_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_timer_t", _wrap_new_avr_timer_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_timer_t", _wrap_delete_avr_timer_t, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_t_swigregister", avr_timer_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_timer_init", _wrap_avr_timer_init, METH_VARARGS, NULL},
+	 { (char *)"TWI_IRQ_INPUT_swigconstant", TWI_IRQ_INPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_IRQ_OUTPUT_swigconstant", TWI_IRQ_OUTPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_IRQ_STATUS_swigconstant", TWI_IRQ_STATUS_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_IRQ_COUNT_swigconstant", TWI_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_START_swigconstant", TWI_COND_START_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_STOP_swigconstant", TWI_COND_STOP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_ADDR_swigconstant", TWI_COND_ADDR_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_ACK_swigconstant", TWI_COND_ACK_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_WRITE_swigconstant", TWI_COND_WRITE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_READ_swigconstant", TWI_COND_READ_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"TWI_COND_SLAVE_swigconstant", TWI_COND_SLAVE_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_unused_set", _wrap_avr_twi_msg_t_unused_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_unused_get", _wrap_avr_twi_msg_t_unused_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_msg_set", _wrap_avr_twi_msg_t_msg_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_msg_get", _wrap_avr_twi_msg_t_msg_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_addr_set", _wrap_avr_twi_msg_t_addr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_addr_get", _wrap_avr_twi_msg_t_addr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_data_set", _wrap_avr_twi_msg_t_data_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_data_get", _wrap_avr_twi_msg_t_data_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_twi_msg_t", _wrap_new_avr_twi_msg_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_twi_msg_t", _wrap_delete_avr_twi_msg_t, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_t_swigregister", avr_twi_msg_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_avr_twi_msg_irq_t", _wrap_new_avr_twi_msg_irq_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_twi_msg_irq_t", _wrap_delete_avr_twi_msg_irq_t, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_msg_irq_t_swigregister", avr_twi_msg_irq_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_io_set", _wrap_avr_twi_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_io_get", _wrap_avr_twi_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_name_set", _wrap_avr_twi_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_name_get", _wrap_avr_twi_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_disabled_set", _wrap_avr_twi_t_disabled_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_disabled_get", _wrap_avr_twi_t_disabled_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twbr_set", _wrap_avr_twi_t_r_twbr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twbr_get", _wrap_avr_twi_t_r_twbr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twcr_set", _wrap_avr_twi_t_r_twcr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twcr_get", _wrap_avr_twi_t_r_twcr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twsr_set", _wrap_avr_twi_t_r_twsr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twsr_get", _wrap_avr_twi_t_r_twsr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twar_set", _wrap_avr_twi_t_r_twar_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twar_get", _wrap_avr_twi_t_r_twar_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twamr_set", _wrap_avr_twi_t_r_twamr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twamr_get", _wrap_avr_twi_t_r_twamr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twdr_set", _wrap_avr_twi_t_r_twdr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_r_twdr_get", _wrap_avr_twi_t_r_twdr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twen_set", _wrap_avr_twi_t_twen_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twen_get", _wrap_avr_twi_t_twen_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twea_set", _wrap_avr_twi_t_twea_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twea_get", _wrap_avr_twi_t_twea_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsta_set", _wrap_avr_twi_t_twsta_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsta_get", _wrap_avr_twi_t_twsta_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsto_set", _wrap_avr_twi_t_twsto_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsto_get", _wrap_avr_twi_t_twsto_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twwc_set", _wrap_avr_twi_t_twwc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twwc_get", _wrap_avr_twi_t_twwc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsr_set", _wrap_avr_twi_t_twsr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twsr_get", _wrap_avr_twi_t_twsr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twps_set", _wrap_avr_twi_t_twps_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twps_get", _wrap_avr_twi_t_twps_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twi_set", _wrap_avr_twi_t_twi_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_twi_get", _wrap_avr_twi_t_twi_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_state_set", _wrap_avr_twi_t_state_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_state_get", _wrap_avr_twi_t_state_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_peer_addr_set", _wrap_avr_twi_t_peer_addr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_peer_addr_get", _wrap_avr_twi_t_peer_addr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_next_twstate_set", _wrap_avr_twi_t_next_twstate_set, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_next_twstate_get", _wrap_avr_twi_t_next_twstate_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_twi_t", _wrap_new_avr_twi_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_twi_t", _wrap_delete_avr_twi_t, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_t_swigregister", avr_twi_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_init", _wrap_avr_twi_init, METH_VARARGS, NULL},
+	 { (char *)"avr_twi_irq_msg", _wrap_avr_twi_irq_msg, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_overflow_f_swigconstant", uart_fifo_overflow_f_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_fifo_size_swigconstant", uart_fifo_fifo_size_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_buffer_set", _wrap_uart_fifo_t_buffer_set, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_buffer_get", _wrap_uart_fifo_t_buffer_get, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_read_set", _wrap_uart_fifo_t_read_set, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_read_get", _wrap_uart_fifo_t_read_get, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_write_set", _wrap_uart_fifo_t_write_set, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_write_get", _wrap_uart_fifo_t_write_get, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_flags_set", _wrap_uart_fifo_t_flags_set, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_flags_get", _wrap_uart_fifo_t_flags_get, METH_VARARGS, NULL},
+	 { (char *)"new_uart_fifo_t", _wrap_new_uart_fifo_t, METH_VARARGS, NULL},
+	 { (char *)"delete_uart_fifo_t", _wrap_delete_uart_fifo_t, METH_VARARGS, NULL},
+	 { (char *)"uart_fifo_t_swigregister", uart_fifo_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"UART_IRQ_INPUT_swigconstant", UART_IRQ_INPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"UART_IRQ_OUTPUT_swigconstant", UART_IRQ_OUTPUT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"UART_IRQ_OUT_XON_swigconstant", UART_IRQ_OUT_XON_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"UART_IRQ_OUT_XOFF_swigconstant", UART_IRQ_OUT_XOFF_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"UART_IRQ_COUNT_swigconstant", UART_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_UART_FLAG_POOL_SLEEP_swigconstant", AVR_UART_FLAG_POOL_SLEEP_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_UART_FLAG_STDIO_swigconstant", AVR_UART_FLAG_STDIO_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_io_set", _wrap_avr_uart_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_io_get", _wrap_avr_uart_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_name_set", _wrap_avr_uart_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_name_get", _wrap_avr_uart_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_disabled_set", _wrap_avr_uart_t_disabled_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_disabled_get", _wrap_avr_uart_t_disabled_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_udr_set", _wrap_avr_uart_t_r_udr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_udr_get", _wrap_avr_uart_t_r_udr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsra_set", _wrap_avr_uart_t_r_ucsra_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsra_get", _wrap_avr_uart_t_r_ucsra_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsrb_set", _wrap_avr_uart_t_r_ucsrb_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsrb_get", _wrap_avr_uart_t_r_ucsrb_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsrc_set", _wrap_avr_uart_t_r_ucsrc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ucsrc_get", _wrap_avr_uart_t_r_ucsrc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_rxen_set", _wrap_avr_uart_t_rxen_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_rxen_get", _wrap_avr_uart_t_rxen_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_txen_set", _wrap_avr_uart_t_txen_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_txen_get", _wrap_avr_uart_t_txen_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_u2x_set", _wrap_avr_uart_t_u2x_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_u2x_get", _wrap_avr_uart_t_u2x_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_usbs_set", _wrap_avr_uart_t_usbs_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_usbs_get", _wrap_avr_uart_t_usbs_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_ucsz_set", _wrap_avr_uart_t_ucsz_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_ucsz_get", _wrap_avr_uart_t_ucsz_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_ucsz2_set", _wrap_avr_uart_t_ucsz2_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_ucsz2_get", _wrap_avr_uart_t_ucsz2_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ubrrl_set", _wrap_avr_uart_t_r_ubrrl_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ubrrl_get", _wrap_avr_uart_t_r_ubrrl_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ubrrh_set", _wrap_avr_uart_t_r_ubrrh_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_r_ubrrh_get", _wrap_avr_uart_t_r_ubrrh_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_rxc_set", _wrap_avr_uart_t_rxc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_rxc_get", _wrap_avr_uart_t_rxc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_txc_set", _wrap_avr_uart_t_txc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_txc_get", _wrap_avr_uart_t_txc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_udrc_set", _wrap_avr_uart_t_udrc_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_udrc_get", _wrap_avr_uart_t_udrc_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_input_set", _wrap_avr_uart_t_input_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_input_get", _wrap_avr_uart_t_input_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_flags_set", _wrap_avr_uart_t_flags_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_flags_get", _wrap_avr_uart_t_flags_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_usec_per_byte_set", _wrap_avr_uart_t_usec_per_byte_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_usec_per_byte_get", _wrap_avr_uart_t_usec_per_byte_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_stdio_out_set", _wrap_avr_uart_t_stdio_out_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_stdio_out_get", _wrap_avr_uart_t_stdio_out_get, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_stdio_len_set", _wrap_avr_uart_t_stdio_len_set, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_stdio_len_get", _wrap_avr_uart_t_stdio_len_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_uart_t", _wrap_new_avr_uart_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_uart_t", _wrap_delete_avr_uart_t, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_t_swigregister", avr_uart_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_uart_init", _wrap_avr_uart_init, METH_VARARGS, NULL},
+	 { (char *)"USB_IRQ_ATTACH_swigconstant", USB_IRQ_ATTACH_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"USB_IRQ_COUNT_swigconstant", USB_IRQ_COUNT_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_pipe_set", _wrap_avr_io_usb_pipe_set, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_pipe_get", _wrap_avr_io_usb_pipe_get, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_sz_set", _wrap_avr_io_usb_sz_set, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_sz_get", _wrap_avr_io_usb_sz_get, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_buf_set", _wrap_avr_io_usb_buf_set, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_buf_get", _wrap_avr_io_usb_buf_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_io_usb", _wrap_new_avr_io_usb, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_io_usb", _wrap_delete_avr_io_usb, METH_VARARGS, NULL},
+	 { (char *)"avr_io_usb_swigregister", avr_io_usb_swigregister, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_NAK_swigconstant", AVR_IOCTL_USB_NAK_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_STALL_swigconstant", AVR_IOCTL_USB_STALL_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"AVR_IOCTL_USB_OK_swigconstant", AVR_IOCTL_USB_OK_swigconstant, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_io_set", _wrap_avr_usb_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_io_get", _wrap_avr_usb_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_name_set", _wrap_avr_usb_t_name_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_name_get", _wrap_avr_usb_t_name_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_disabled_set", _wrap_avr_usb_t_disabled_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_disabled_get", _wrap_avr_usb_t_disabled_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usbrf_set", _wrap_avr_usb_t_usbrf_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usbrf_get", _wrap_avr_usb_t_usbrf_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_r_usbcon_set", _wrap_avr_usb_t_r_usbcon_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_r_usbcon_get", _wrap_avr_usb_t_r_usbcon_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_r_pllcsr_set", _wrap_avr_usb_t_r_pllcsr_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_r_pllcsr_get", _wrap_avr_usb_t_r_pllcsr_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usb_com_vect_set", _wrap_avr_usb_t_usb_com_vect_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usb_com_vect_get", _wrap_avr_usb_t_usb_com_vect_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usb_gen_vect_set", _wrap_avr_usb_t_usb_gen_vect_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_usb_gen_vect_get", _wrap_avr_usb_t_usb_gen_vect_get, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_state_set", _wrap_avr_usb_t_state_set, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_state_get", _wrap_avr_usb_t_state_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_usb_t", _wrap_new_avr_usb_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_usb_t", _wrap_delete_avr_usb_t, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_t_swigregister", avr_usb_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_usb_init", _wrap_avr_usb_init, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_io_set", _wrap_avr_watchdog_t_io_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_io_get", _wrap_avr_watchdog_t_io_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdrf_set", _wrap_avr_watchdog_t_wdrf_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdrf_get", _wrap_avr_watchdog_t_wdrf_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdce_set", _wrap_avr_watchdog_t_wdce_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdce_get", _wrap_avr_watchdog_t_wdce_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wde_set", _wrap_avr_watchdog_t_wde_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wde_get", _wrap_avr_watchdog_t_wde_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdp_set", _wrap_avr_watchdog_t_wdp_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_wdp_get", _wrap_avr_watchdog_t_wdp_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_watchdog_set", _wrap_avr_watchdog_t_watchdog_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_watchdog_get", _wrap_avr_watchdog_t_watchdog_get, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_cycle_count_set", _wrap_avr_watchdog_t_cycle_count_set, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_cycle_count_get", _wrap_avr_watchdog_t_cycle_count_get, METH_VARARGS, NULL},
+	 { (char *)"new_avr_watchdog_t", _wrap_new_avr_watchdog_t, METH_VARARGS, NULL},
+	 { (char *)"delete_avr_watchdog_t", _wrap_delete_avr_watchdog_t, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_t_swigregister", avr_watchdog_t_swigregister, METH_VARARGS, NULL},
+	 { (char *)"avr_watchdog_init", _wrap_avr_watchdog_init, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }
 };
 
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
+static swig_type_info _swigt__p_IRQCallback = {"_p_IRQCallback", "IRQCallback *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_LoggerCallback = {"_p_LoggerCallback", "LoggerCallback *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_TimerCallback = {"_p_TimerCallback", "TimerCallback *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_adc_mux_t = {"_p_avr_adc_mux_t", "avr_adc_mux_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_adc_t = {"_p_avr_adc_t", "avr_adc_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_adts_type = {"_p_avr_adts_type", "enum avr_adts_type *|avr_adts_type *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_eeprom_desc_t = {"_p_avr_eeprom_desc_t", "avr_eeprom_desc_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_eeprom_t = {"_p_avr_eeprom_t", "avr_eeprom_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_extint_t = {"_p_avr_extint_t", "avr_extint_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_flash_t = {"_p_avr_flash_t", "avr_flash_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_int_vector_t = {"_p_avr_int_vector_t", "avr_int_vector_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_io_addr_t = {"_p_avr_io_addr_t", "avr_io_addr_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_io_t = {"_p_avr_io_t", "avr_io_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_io_usb = {"_p_avr_io_usb", "avr_io_usb *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_iopin_t = {"_p_avr_iopin_t", "avr_iopin_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_ioport_external_t = {"_p_avr_ioport_external_t", "avr_ioport_external_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_ioport_getirq_t = {"_p_avr_ioport_getirq_t", "avr_ioport_getirq_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_ioport_state_t = {"_p_avr_ioport_state_t", "avr_ioport_state_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_ioport_t = {"_p_avr_ioport_t", "avr_ioport_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_irq_t = {"_p_avr_irq_t", "avr_irq_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_regbit_t = {"_p_avr_regbit_t", "avr_regbit_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_spi_t = {"_p_avr_spi_t", "avr_spi_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_avr_t = {"_p_avr_t", "avr_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_timer_comp_t = {"_p_avr_timer_comp_t", "avr_timer_comp_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_timer_t = {"_p_avr_timer_t", "avr_timer_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_timer_wgm_t = {"_p_avr_timer_wgm_t", "avr_timer_wgm_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_twi_msg_irq_t = {"_p_avr_twi_msg_irq_t", "avr_twi_msg_irq_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_twi_msg_t = {"_p_avr_twi_msg_t", "avr_twi_msg_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_twi_t = {"_p_avr_twi_t", "avr_twi_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_uart_t = {"_p_avr_uart_t", "avr_uart_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_usb_t = {"_p_avr_usb_t", "avr_usb_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_avr_watchdog_t = {"_p_avr_watchdog_t", "avr_watchdog_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_p_avr_irq_t = {"_p_p_avr_irq_t", "avr_irq_t **", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uart_fifo_t = {"_p_uart_fifo_t", "uart_fifo_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint16_t = {"_p_uint16_t", "uint16_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint64_t = {"_p_uint64_t", "uint64_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_uint8_t = {"_p_uint8_t", "uint8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_usb_internal_state = {"_p_usb_internal_state", "usb_internal_state *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
+  &_swigt__p_IRQCallback,
   &_swigt__p_LoggerCallback,
   &_swigt__p_TimerCallback,
+  &_swigt__p_avr_adc_mux_t,
+  &_swigt__p_avr_adc_t,
+  &_swigt__p_avr_adts_type,
+  &_swigt__p_avr_eeprom_desc_t,
+  &_swigt__p_avr_eeprom_t,
+  &_swigt__p_avr_extint_t,
+  &_swigt__p_avr_flash_t,
+  &_swigt__p_avr_int_vector_t,
+  &_swigt__p_avr_io_addr_t,
+  &_swigt__p_avr_io_t,
+  &_swigt__p_avr_io_usb,
+  &_swigt__p_avr_iopin_t,
+  &_swigt__p_avr_ioport_external_t,
+  &_swigt__p_avr_ioport_getirq_t,
+  &_swigt__p_avr_ioport_state_t,
+  &_swigt__p_avr_ioport_t,
+  &_swigt__p_avr_irq_t,
+  &_swigt__p_avr_regbit_t,
+  &_swigt__p_avr_spi_t,
   &_swigt__p_avr_t,
+  &_swigt__p_avr_timer_comp_t,
+  &_swigt__p_avr_timer_t,
+  &_swigt__p_avr_timer_wgm_t,
+  &_swigt__p_avr_twi_msg_irq_t,
+  &_swigt__p_avr_twi_msg_t,
+  &_swigt__p_avr_twi_t,
+  &_swigt__p_avr_uart_t,
+  &_swigt__p_avr_usb_t,
+  &_swigt__p_avr_watchdog_t,
   &_swigt__p_char,
+  &_swigt__p_p_avr_irq_t,
+  &_swigt__p_uart_fifo_t,
+  &_swigt__p_uint16_t,
+  &_swigt__p_uint64_t,
+  &_swigt__p_uint8_t,
+  &_swigt__p_usb_internal_state,
 };
 
+static swig_cast_info _swigc__p_IRQCallback[] = {  {&_swigt__p_IRQCallback, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_LoggerCallback[] = {  {&_swigt__p_LoggerCallback, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_TimerCallback[] = {  {&_swigt__p_TimerCallback, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_adc_mux_t[] = {  {&_swigt__p_avr_adc_mux_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_adc_t[] = {  {&_swigt__p_avr_adc_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_adts_type[] = {  {&_swigt__p_avr_adts_type, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_eeprom_desc_t[] = {  {&_swigt__p_avr_eeprom_desc_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_eeprom_t[] = {  {&_swigt__p_avr_eeprom_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_extint_t[] = {  {&_swigt__p_avr_extint_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_flash_t[] = {  {&_swigt__p_avr_flash_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_int_vector_t[] = {  {&_swigt__p_avr_int_vector_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_io_addr_t[] = {  {&_swigt__p_avr_io_addr_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_io_t[] = {  {&_swigt__p_avr_io_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_io_usb[] = {  {&_swigt__p_avr_io_usb, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_iopin_t[] = {  {&_swigt__p_avr_iopin_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_ioport_external_t[] = {  {&_swigt__p_avr_ioport_external_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_ioport_getirq_t[] = {  {&_swigt__p_avr_ioport_getirq_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_ioport_state_t[] = {  {&_swigt__p_avr_ioport_state_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_ioport_t[] = {  {&_swigt__p_avr_ioport_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_irq_t[] = {  {&_swigt__p_avr_irq_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_regbit_t[] = {  {&_swigt__p_avr_regbit_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_spi_t[] = {  {&_swigt__p_avr_spi_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_avr_t[] = {  {&_swigt__p_avr_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_timer_comp_t[] = {  {&_swigt__p_avr_timer_comp_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_timer_t[] = {  {&_swigt__p_avr_timer_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_timer_wgm_t[] = {  {&_swigt__p_avr_timer_wgm_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_twi_msg_irq_t[] = {  {&_swigt__p_avr_twi_msg_irq_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_twi_msg_t[] = {  {&_swigt__p_avr_twi_msg_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_twi_t[] = {  {&_swigt__p_avr_twi_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_uart_t[] = {  {&_swigt__p_avr_uart_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_usb_t[] = {  {&_swigt__p_avr_usb_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_avr_watchdog_t[] = {  {&_swigt__p_avr_watchdog_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_avr_irq_t[] = {  {&_swigt__p_p_avr_irq_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_uart_fifo_t[] = {  {&_swigt__p_uart_fifo_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_uint16_t[] = {  {&_swigt__p_uint16_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_uint64_t[] = {  {&_swigt__p_uint64_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_uint8_t[] = {  {&_swigt__p_uint8_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_usb_internal_state[] = {  {&_swigt__p_usb_internal_state, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
+  _swigc__p_IRQCallback,
   _swigc__p_LoggerCallback,
   _swigc__p_TimerCallback,
+  _swigc__p_avr_adc_mux_t,
+  _swigc__p_avr_adc_t,
+  _swigc__p_avr_adts_type,
+  _swigc__p_avr_eeprom_desc_t,
+  _swigc__p_avr_eeprom_t,
+  _swigc__p_avr_extint_t,
+  _swigc__p_avr_flash_t,
+  _swigc__p_avr_int_vector_t,
+  _swigc__p_avr_io_addr_t,
+  _swigc__p_avr_io_t,
+  _swigc__p_avr_io_usb,
+  _swigc__p_avr_iopin_t,
+  _swigc__p_avr_ioport_external_t,
+  _swigc__p_avr_ioport_getirq_t,
+  _swigc__p_avr_ioport_state_t,
+  _swigc__p_avr_ioport_t,
+  _swigc__p_avr_irq_t,
+  _swigc__p_avr_regbit_t,
+  _swigc__p_avr_spi_t,
   _swigc__p_avr_t,
+  _swigc__p_avr_timer_comp_t,
+  _swigc__p_avr_timer_t,
+  _swigc__p_avr_timer_wgm_t,
+  _swigc__p_avr_twi_msg_irq_t,
+  _swigc__p_avr_twi_msg_t,
+  _swigc__p_avr_twi_t,
+  _swigc__p_avr_uart_t,
+  _swigc__p_avr_usb_t,
+  _swigc__p_avr_watchdog_t,
   _swigc__p_char,
+  _swigc__p_p_avr_irq_t,
+  _swigc__p_uart_fifo_t,
+  _swigc__p_uint16_t,
+  _swigc__p_uint64_t,
+  _swigc__p_uint8_t,
+  _swigc__p_usb_internal_state,
 };
 
 

--- a/pysimavr/swig/utils_wrap.h
+++ b/pysimavr/swig/utils_wrap.h
@@ -99,4 +99,46 @@ private:
 };
 
 
+class SwigDirector_IRQCallback : public IRQCallback, public Swig::Director {
+
+public:
+    SwigDirector_IRQCallback(PyObject *self, avr_irq_t *irq);
+    virtual ~SwigDirector_IRQCallback();
+    virtual void on_notify(avr_irq_t *irq, uint32_t value);
+
+/* Internal director utilities */
+public:
+    bool swig_get_inner(const char *swig_protected_method_name) const {
+      std::map<std::string, bool>::const_iterator iv = swig_inner.find(swig_protected_method_name);
+      return (iv != swig_inner.end() ? iv->second : false);
+    }
+    void swig_set_inner(const char *swig_protected_method_name, bool swig_val) const {
+      swig_inner[swig_protected_method_name] = swig_val;
+    }
+private:
+    mutable std::map<std::string, bool> swig_inner;
+
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+/* VTable implementation */
+    PyObject *swig_get_method(size_t method_index, const char *method_name) const {
+      PyObject *method = vtable[method_index];
+      if (!method) {
+        swig::SwigVar_PyObject name = SWIG_Python_str_FromChar(method_name);
+        method = PyObject_GetAttr(swig_get_self(), name);
+        if (!method) {
+          std::string msg = "Method in class IRQCallback doesn't exist, undefined ";
+          msg += method_name;
+          Swig::DirectorMethodException::raise(msg.c_str());
+        }
+        vtable[method_index] = method;
+      }
+      return method;
+    }
+private:
+    mutable swig::SwigVar_PyObject vtable[1];
+#endif
+
+};
+
+
 #endif

--- a/pysimavr/timer.py
+++ b/pysimavr/timer.py
@@ -2,22 +2,25 @@ from pysimavr.swig.utils import TimerCallback
 import traceback
 
 class Timer(TimerCallback):
-    """Wraps the simavr cycle_timer functionality. Enables to hook a python method
+    """ Wraps the simavr cycle_timer functionality. Enables to hook a python method
     to be called every x simavr cycles. 
-    """        
-    
+
+    Note there is usually no need to create instance of this class directly as there is a 
+    helper :func:`avr.timer <pysimavr.avr.Avr.timer>` method available.
+    """
+
     def __init__(self, avr, callback=None):
         TimerCallback.__init__(self, avr)
         #super(TimerCallback, self).__init__()
         self._callback = callback
-        
-    
+
+
     def on_timer(self, when):
         """ The callback called from simavr.
-        :Parameters:
-            `when` : The exact simavr cycle number. Note actual cycle number could be
+
+        :param when: The exact simavr cycle number. Note actual cycle number could be
                 slightly off the requested one.
-        :Returns: The new cycle number the next callback should be invoked. 
+        :return: The new cycle number the next callback should be invoked. 
                 Or zero to cancel the callback.           
         """
         if self._callback:
@@ -26,14 +29,11 @@ class Timer(TimerCallback):
                 #Log any python exception here since py stacktrace is not propagated down to C++ and it would be lost
                 traceback.print_exc()
                 raise
-            
-            
-            
+
     @property
     def callback(self):
         return self._callback;
-    
+
     @callback.setter
     def callback(self, callback):
         self._callback = callback
-    

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -1,0 +1,110 @@
+from mock import Mock
+#from unittest.mock import Mock
+from pyavrutils import AvrGcc
+from pysimavr.avr import Avr
+from pysimavr.firmware import Firmware
+from pysimavr.swig.simavr import avr_raise_irq, IRQ_FLAG_FILTERED
+import pysimavr.swig.utils as utils
+from hamcrest import assert_that, equal_to, close_to
+
+def test_io_irq():
+    mcu = 'attiny2313'
+    cc = AvrGcc(mcu=mcu)
+    # The code just sets one pin an output and pulse the digial IO
+    code = '''
+    #include <avr/io.h>
+
+    int main(){
+        PORTB|=  _BV(PORTB5); //B5 pullup. To avoid possible oscilation on DD change
+        DDRB |=  _BV(DDB5);   //B5 output
+        PORTB|=  _BV(PORTB5); //B5 high
+        PORTB&= ~_BV(PORTB5); //B5 low
+        while(1); //Avoid ramend run out. Although gcc probably generates this already.
+    }
+    '''
+
+    cc.build(code)
+    fw = Firmware(cc.output)
+
+    callbackMock = Mock()
+
+    avr = Avr(mcu=mcu, firmware=fw, f_cpu=8000000)
+    avr.irq.ioport_register_notify(callbackMock, ('B', 5))
+
+    avr.step(10000)
+
+    assert_that(callbackMock.call_count, equal_to(2), "Number of IRQ callback invocations.")
+    avr.terminate()
+
+def test_adc_irq():
+    mcu = 'atmega2560'
+    feedmv = 2400  # 2.4 volts
+
+    cc = AvrGcc(mcu=mcu)
+    # The code do one ADC and "sends" the captured value back as 16bit number using the A and B ports
+    code = '''
+    #include <avr/io.h>
+
+    int main(){
+        DDRB =  0xFF;   //A output
+        DDRA =  0xFF;   //B output
+
+        //Init ADC
+        ADMUX = (1 << MUX1)| (1 << REFS0);// Select MUTEX to ADC2, and VCC reference
+        ADCSRB = 0;
+        //Set 64 Prescaler division = (125khz @ 8MHZ clock) and enable.
+        ADCSRA = (1 << ADEN) |(1 << ADPS2) | (1 << ADPS1) | (0 << ADPS0);
+        ADCSRA|= (1 << ADSC); //Start conversion. Single Conversion mode.
+        while (ADCSRA & (1 << ADSC)); //Wait for the conv. to finish
+
+        //Use all the bits of the port A and B to "send" the converted value back to the test.
+        PORTB = ADCL;
+        PORTA = ADCH;
+
+        while(1);
+    }
+    '''
+
+    cc.build(code)
+    fw = Firmware(cc.output)
+    avr = Avr(mcu=mcu, firmware=fw, f_cpu=4000000)
+
+    # Called once AVR starts the ADC.
+    def adcCallback(irq, newVal):
+        # Feed the analog value (in milivolts) to the ADC2.
+        irq_t = avr.irq.getadc(utils.ADC_IRQ_ADC2)
+        avr_raise_irq(irq_t, feedmv)
+
+    # Wrap further to Mock object to enable recording the number of calls.
+    adcCallbackMock = Mock(side_effect=adcCallback)
+    avr.irq.adc_register_notify(adcCallbackMock)
+
+    # The result value "sent" back from simulated code. Need to wrap the variable into an array 
+    # to workaround the "referenced before assignment" errors.
+    result = [0]  
+
+    # Called each time A or B port is changed
+    def portCallback(irq, newVal):
+        if irq.name[0] == 'A':
+            newVal = newVal << 8
+        result[0] += newVal
+
+    portCallbackMock = Mock(side_effect=portCallback)
+
+    for port in ('A', 'B'):
+        p = avr.irq.ioport_register_notify(portCallbackMock, (port, utils.IOPORT_IRQ_PIN_ALL))
+        p.get_irq().name = port  # Rename the IO IRQs to ease the Word recomposition in the callback
+        # Force callback even on unchanged port values. Just to always have the same number of callback calls.
+        p.get_irq().flags &= ~IRQ_FLAG_FILTERED 
+
+    avr.step(10000)
+
+    assert_that(adcCallbackMock.call_count, equal_to(1), "Number of ADC trigger_out callback invocations.")
+
+    # The port A and B callback gets triggeret at startup first when they are set to output. Two 0 values are sent. 
+    # And later when the result value is being send back. Hence 4x.     
+    assert_that(portCallbackMock.call_count, equal_to(4), "Number of IO IRQ callback invocations.")
+    expectedAdc = avr.vcc * 1000 * result[0] / 1024  # 10 bit ADC. VCC used as vref.
+    assert_that(expectedAdc, close_to(feedmv, 10), "ADC result")
+
+    avr.terminate()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -4,25 +4,25 @@ from mock import Mock
 from nose.tools import eq_
 from pysimavr.avr import Avr
 from pysimavr.swig.simavr import cpu_Running 
-from hamcrest import assert_that, close_to, greater_than, equal_to, none, is_
+from hamcrest import assert_that, close_to, greater_than, equal_to, none, is_, not_none
 import weakref
 import gc
 
 def test_timer_simple():
-    avr = Avr(mcu='atmega88', f_cpu=8000000)    
+    avr = Avr(mcu='atmega88', f_cpu=8000000)
     # Callback method mocked out. 
     callbackMock = Mock(return_value=0)
-    
+
     #Schedule callback at 20uSec.  
     # cycles = avr->frequency * (avr_cycle_count_t)usec / 1000000;
     timer = avr.timer(callbackMock, uSec=20)
-         
+
     assert_that(timer.status(), close_to(8000000*20/1000000, 10), 
                 "uSec to cycles convertion")    
-    
+
     avr.step(1000)
     eq_(avr.state, cpu_Running, "mcu is not running")
-            
+
     eq_(callbackMock.call_count, 1, "number of calback invocations")
     avr.terminate()
 
@@ -31,44 +31,54 @@ def test_timer_reoccuring():
     # Callback method mocked out. It will register another callback 
     # at 200 cycles and then cancel by returning 0.
     callbackMock = Mock(side_effect = [200, 0])
-    
+
     timer = avr.timer(callbackMock)
     avr.step(10)
     eq_(avr.state, cpu_Running, "mcu is not running")
     callbackMock.assert_not_called()
-    
+
     # Request first timer callback at 100 cycles
     timer.set_timer_cycles(100)    
-    
+
     # Run long enought to ensure callback is canceled by returning 0 on the second invocation.
     avr.step(1000)
     eq_(avr.state, cpu_Running, "mcu is not running")
     eq_(callbackMock.call_count, 2, "number of calback invocations")
-        
+
     lastCallFirstArg = callbackMock.call_args[0][0]    
     assert_that(lastCallFirstArg, close_to(200, 10), 
                 "The last cycle number received in the callback doesn't match the requested one") 
     avr.terminate()
-    
+
 def test_timer_cancel():
     avr = Avr(mcu='atmega88', f_cpu=1000000)
     callbackMock = Mock(return_value=200)
     timer = avr.timer(callbackMock, cycle=50)    
     avr.step(10)
     callbackMock.assert_not_called()
-    
+
     timer.cancel()
     avr.step(1000)
     callbackMock.assert_not_called()    
-         
+
     avr.terminate()
-    
+
 def test_timer_GC():
     avr = Avr(mcu='atmega88', f_cpu=1000000)
     callbackMock = Mock(return_value=0)
-    t = weakref.ref(avr.timer(callbackMock, cycle=10))
+    #Don't let avr object to keep the callback referenced.
+    t = weakref.ref(avr.timer(callbackMock, cycle=10, keepalive=False))
     gc.collect()
     assert_that(t(), is_(none()), "Orphan Timer didn't get garbage collected.")
     avr.step(100)
-    assert_that(callbackMock.call_count, equal_to(0), "Number of IRQ callback invocations.")        
+    assert_that(callbackMock.call_count, equal_to(0), "Number of IRQ callback invocations.")
+
+    #Now let avr object keep the callback alive.
+    t = weakref.ref(avr.timer(callbackMock, cycle=110, keepalive=True))
+    gc.collect()
+    assert_that(t(), is_ (not_none()), "Avr object didn't kept Timer callback alive.")
+    avr.step(1000)
+    assert_that(callbackMock.call_count, equal_to(1), "Number of IRQ callback invocations.")                   
     avr.terminate()
+    gc.collect()
+    assert_that(t(), is_(none()), "Orphan Timer didn't get garbage collected even after Avr is terminated.")


### PR DESCRIPTION
The callback implemeted also the IRQ stuff.
* There are helper methods created in the `irq` module. Which is accessible on the main `avr` object.
* Currently helpers are only created for digital IO and ADC. But all the required IRQ methods/macros I found are already exposed on the swig level in the utils.i.
For example to register a callback on pin change:
```
avr.irq.ioport_register_notify(myCallable, ("A", 6))
```
More comperhensive usage is in the `test_irq.py`.

This enables both-way communication between Python and simavr core. No need to create custom parts in C anymore just to be able to watch pin change etc.